### PR TITLE
feat(prd-15): implement M5 Telegram Bot Integration

### DIFF
--- a/prds/15-m5-telegram-bot.md
+++ b/prds/15-m5-telegram-bot.md
@@ -5,7 +5,7 @@
 **Issue**: #15
 **Parent**: #10 (Alfred - The Rememberer)
 **Depends On**: #12 (M2: Core Infrastructure)
-**Status**: Planning
+**Status**: Complete
 **Priority**: High
 **Created**: 2026-02-16
 
@@ -33,12 +33,12 @@ Build async Telegram bot as a thin interface:
 
 ## Acceptance Criteria
 
-- [ ] `src/interfaces/telegram.py` - Telegram bot implementation
-- [ ] `src/interfaces/cli.py` - CLI interface (parallel implementation)
-- [ ] Async message handling
-- [ ] Delegation to core Alfred engine (not direct memory/context access)
-- [ ] Error handling with user feedback
-- [ ] Support for `/compact` command
+- [x] `src/interfaces/telegram.py` - Telegram bot implementation
+- [x] `src/interfaces/cli.py` - CLI interface (parallel implementation)
+- [x] Async message handling
+- [x] Delegation to core Alfred engine (not direct memory/context access)
+- [x] Error handling with user feedback
+- [x] Support for `/compact` command
 
 ---
 
@@ -362,10 +362,10 @@ services:
 
 ## Success Criteria
 
-- [ ] Bot responds to /start
-- [ ] Bot delegates all chat to Alfred.chat()
-- [ ] CLI interface works with same Alfred engine
-- [ ] /compact command delegates to Alfred.compact()
-- [ ] Errors surface to user
-- [ ] All async operations work correctly
-- [ ] Type-safe throughout
+- [x] Bot responds to /start
+- [x] Bot delegates all chat to Alfred.chat()
+- [x] CLI interface works with same Alfred engine
+- [x] /compact command delegates to Alfred.compact()
+- [x] Errors surface to user
+- [x] All async operations work correctly
+- [x] Type-safe throughout

--- a/src/alfred.py
+++ b/src/alfred.py
@@ -1,0 +1,44 @@
+"""Core Alfred engine - orchestrates memory, context, and LLM."""
+
+import logging
+
+from src.config import Config
+from src.context import ContextLoader
+from src.llm import ChatMessage, ChatResponse, LLMFactory
+
+logger = logging.getLogger(__name__)
+
+
+class Alfred:
+    """Core Alfred engine - handles memory, context, and LLM."""
+
+    def __init__(self, config: Config) -> None:
+        self.config = config
+        self.llm = LLMFactory.create(config)
+        self.context_loader = ContextLoader(config)
+
+    async def chat(self, message: str) -> ChatResponse:
+        """Process a message and return response.
+
+        This is the main entry point for any interface.
+        Handles: load context → build prompt → call LLM → return response
+        """
+        # 1. Load context (agents, soul, user, tools)
+        context = await self.context_loader.assemble()
+
+        # 2. Build messages
+        messages = [
+            ChatMessage(role="system", content=context.system_prompt),
+            ChatMessage(role="user", content=message),
+        ]
+
+        # 3. Call LLM
+        response = await self.llm.chat(messages)
+
+        logger.info(f"Chat completed: {response.usage}")
+        return response
+
+    async def compact(self) -> str:
+        """Trigger conversation compaction."""
+        # TODO: Implement in M9
+        return "Compaction not yet implemented"

--- a/src/interfaces/__init__.py
+++ b/src/interfaces/__init__.py
@@ -1,0 +1,1 @@
+"""Interface adapters for Alfred (Telegram, CLI, etc.)."""

--- a/src/interfaces/cli.py
+++ b/src/interfaces/cli.py
@@ -1,0 +1,59 @@
+"""CLI interface for Alfred."""
+
+import asyncio
+import logging
+
+from src.alfred import Alfred
+from src.config import Config
+
+logger = logging.getLogger(__name__)
+
+
+class CLIInterface:
+    """CLI interface - delegates to Alfred engine."""
+
+    def __init__(self, config: Config, alfred: Alfred) -> None:
+        self.config = config
+        self.alfred = alfred
+
+    async def run(self) -> None:
+        """Run interactive CLI."""
+        print("Alfred CLI. Type 'exit' to quit, 'compact' to compact.\n")
+
+        while True:
+            try:
+                user_input = input("You: ").strip()
+            except EOFError:
+                break
+
+            if not user_input:
+                continue
+
+            if user_input.lower() == "exit":
+                print("Goodbye!")
+                break
+
+            if user_input.lower() == "compact":
+                result = await self.alfred.compact()
+                print(f"Alfred: {result}\n")
+                continue
+
+            response = await self.alfred.chat(user_input)
+            print(f"Alfred: {response.content}\n")
+
+
+async def main() -> None:
+    """Entry point."""
+    from src.config import load_config
+
+    logging.basicConfig(level=logging.INFO)
+
+    config = load_config()
+    alfred = Alfred(config)
+    interface = CLIInterface(config, alfred)
+
+    await interface.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/interfaces/telegram.py
+++ b/src/interfaces/telegram.py
@@ -1,0 +1,109 @@
+"""Telegram bot interface for Alfred."""
+
+import logging
+
+from telegram import Update
+from telegram.ext import (
+    Application,
+    CommandHandler,
+    ContextTypes,
+    MessageHandler,
+    filters,
+)
+
+from src.alfred import Alfred
+from src.config import Config
+
+logger = logging.getLogger(__name__)
+
+
+class TelegramInterface:
+    """Thin Telegram interface - delegates to Alfred engine."""
+
+    def __init__(self, config: Config, alfred: Alfred) -> None:
+        self.config = config
+        self.alfred = alfred
+        self.application: Application | None = None
+
+    def setup(self) -> Application:
+        """Initialize telegram application."""
+        self.application = (
+            Application.builder()
+            .token(self.config.telegram_bot_token)
+            .build()
+        )
+
+        self.application.add_handler(CommandHandler("start", self.start))
+        self.application.add_handler(CommandHandler("compact", self.compact))
+        self.application.add_handler(
+            MessageHandler(filters.TEXT & ~filters.COMMAND, self.message)
+        )
+
+        return self.application
+
+    async def start(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Handle /start command."""
+        if not update.message:
+            return
+
+        await update.message.reply_text(
+            "Hello, I'm Alfred. I remember our conversations."
+        )
+
+    async def compact(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Handle /compact command."""
+        if not update.message:
+            return
+
+        result = await self.alfred.compact()
+        await update.message.reply_text(result)
+
+    async def message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Handle text messages - delegate to Alfred."""
+        if not update.message or not update.message.text:
+            return
+
+        try:
+            response = await self.alfred.chat(update.message.text)
+            await update.message.reply_text(response.content)
+        except Exception as e:
+            logger.exception("Error handling message")
+            await update.message.reply_text(f"Error: {e}. Please try again.")
+            raise  # Fail fast
+
+    async def run(self) -> None:
+        """Run the bot."""
+        if not self.application:
+            self.setup()
+
+        await self.application.initialize()
+        await self.application.start()
+        await self.application.updater.start_polling()
+
+        logger.info("Bot started. Press Ctrl+C to stop.")
+
+        # Keep running until interrupted
+        try:
+            await self.application.updater.idle()
+        finally:
+            await self.application.updater.stop()
+            await self.application.stop()
+
+
+async def main() -> None:
+    """Entry point."""
+    from src.config import load_config
+
+    logging.basicConfig(level=logging.INFO)
+
+    config = load_config()
+    alfred = Alfred(config)
+    interface = TelegramInterface(config, alfred)
+
+    await interface.run()
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(main())

--- a/tests/test_alfred.py
+++ b/tests/test_alfred.py
@@ -1,0 +1,101 @@
+"""Tests for Alfred core engine."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.alfred import Alfred
+from src.llm import ChatResponse
+
+
+@pytest.fixture
+def mock_config():
+    """Create a mock config."""
+    config = MagicMock()
+    config.default_llm_provider = "kimi"
+    config.context_files = {
+        "agents": MagicMock(),
+        "soul": MagicMock(),
+        "user": MagicMock(),
+        "tools": MagicMock(),
+    }
+    return config
+
+
+@pytest.fixture
+def mock_context():
+    """Create a mock assembled context."""
+    context = MagicMock()
+    context.system_prompt = "You are Alfred, a helpful assistant."
+    context.memories = []
+    return context
+
+
+@pytest.mark.asyncio
+async def test_chat_returns_response(mock_config, mock_context):
+    """Test that chat returns a ChatResponse."""
+    with (
+        patch("src.alfred.LLMFactory") as mock_factory,
+        patch("src.alfred.ContextLoader") as mock_loader_class,
+    ):
+        # Mock the LLM provider
+        mock_llm = AsyncMock()
+        mock_llm.chat.return_value = ChatResponse(
+            content="Hello! How can I help you?",
+            model="kimi",
+            usage={"prompt_tokens": 10, "completion_tokens": 8},
+        )
+        mock_factory.create.return_value = mock_llm
+
+        # Mock the context loader
+        mock_loader = AsyncMock()
+        mock_loader.assemble.return_value = mock_context
+        mock_loader_class.return_value = mock_loader
+
+        alfred = Alfred(mock_config)
+        response = await alfred.chat("Hello Alfred")
+
+        assert isinstance(response, ChatResponse)
+        assert response.content == "Hello! How can I help you?"
+        mock_llm.chat.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_chat_builds_correct_messages(mock_config, mock_context):
+    """Test that chat builds messages with system prompt and user input."""
+    with (
+        patch("src.alfred.LLMFactory") as mock_factory,
+        patch("src.alfred.ContextLoader") as mock_loader_class,
+    ):
+        mock_llm = AsyncMock()
+        mock_llm.chat.return_value = ChatResponse(content="Response", model="kimi")
+        mock_factory.create.return_value = mock_llm
+
+        mock_loader = AsyncMock()
+        mock_loader.assemble.return_value = mock_context
+        mock_loader_class.return_value = mock_loader
+
+        alfred = Alfred(mock_config)
+        await alfred.chat("Test message")
+
+        # Verify messages were built correctly
+        call_args = mock_llm.chat.call_args
+        messages = call_args[0][0]
+
+        assert len(messages) == 2
+        assert messages[0].role == "system"
+        assert messages[0].content == "You are Alfred, a helpful assistant."
+        assert messages[1].role == "user"
+        assert messages[1].content == "Test message"
+
+
+@pytest.mark.asyncio
+async def test_compact_returns_placeholder(mock_config):
+    """Test that compact returns placeholder message."""
+    with (
+        patch("src.alfred.LLMFactory"),
+        patch("src.alfred.ContextLoader"),
+    ):
+        alfred = Alfred(mock_config)
+        result = await alfred.compact()
+
+        assert result == "Compaction not yet implemented"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,102 @@
+"""Tests for CLI interface."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from io import StringIO
+
+from src.interfaces.cli import CLIInterface
+from src.alfred import Alfred
+from src.config import Config
+from src.llm import ChatResponse
+
+
+@pytest.fixture
+def mock_config():
+    """Create a mock config."""
+    return MagicMock(spec=Config)
+
+
+@pytest.fixture
+def mock_alfred():
+    """Create a mock Alfred engine."""
+    alfred = MagicMock(spec=Alfred)
+    alfred.chat = AsyncMock(
+        return_value=ChatResponse(content="CLI response", model="kimi")
+    )
+    alfred.compact = AsyncMock(return_value="Compacted")
+    return alfred
+
+
+@pytest.mark.asyncio
+async def test_chat_delegates_to_alfred(mock_config, mock_alfred):
+    """Test that CLI delegates chat to Alfred."""
+    interface = CLIInterface(mock_config, mock_alfred)
+
+    with patch("sys.stdin", StringIO("Hello\nexit\n")):
+        with patch("sys.stdout", StringIO()):
+            await interface.run()
+
+    mock_alfred.chat.assert_called_once_with("Hello")
+
+
+@pytest.mark.asyncio
+async def test_compact_delegates_to_alfred(mock_config, mock_alfred):
+    """Test that CLI delegates compact to Alfred."""
+    interface = CLIInterface(mock_config, mock_alfred)
+
+    with patch("sys.stdin", StringIO("compact\nexit\n")):
+        with patch("sys.stdout", StringIO()):
+            await interface.run()
+
+    mock_alfred.compact.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_exit_terminates_loop(mock_config, mock_alfred):
+    """Test that 'exit' command terminates the loop."""
+    interface = CLIInterface(mock_config, mock_alfred)
+
+    with patch("sys.stdin", StringIO("exit\n")):
+        with patch("sys.stdout", StringIO()):
+            await interface.run()
+
+    # Should not call chat
+    mock_alfred.chat.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_empty_input_ignored(mock_config, mock_alfred):
+    """Test that empty input is ignored."""
+    interface = CLIInterface(mock_config, mock_alfred)
+
+    with patch("sys.stdin", StringIO("\n\nHello\nexit\n")):
+        with patch("sys.stdout", StringIO()):
+            await interface.run()
+
+    # Only one chat call for "Hello"
+    mock_alfred.chat.assert_called_once_with("Hello")
+
+
+@pytest.mark.asyncio
+async def test_eoferror_terminates_loop(mock_config, mock_alfred):
+    """Test that EOFError terminates the loop gracefully."""
+    interface = CLIInterface(mock_config, mock_alfred)
+
+    # Simulate EOFError on first input
+    with patch("builtins.input", side_effect=EOFError):
+        await interface.run()
+
+    # Should not call chat
+    mock_alfred.chat.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_case_insensitive_commands(mock_config, mock_alfred):
+    """Test that commands are case-insensitive."""
+    interface = CLIInterface(mock_config, mock_alfred)
+
+    with patch("sys.stdin", StringIO("COMPACT\nEXIT\n")):
+        with patch("sys.stdout", StringIO()):
+            await interface.run()
+
+    mock_alfred.compact.assert_called_once()

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -1,0 +1,142 @@
+"""Tests for Telegram interface."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from src.interfaces.telegram import TelegramInterface
+from src.alfred import Alfred
+from src.config import Config
+from src.llm import ChatResponse
+
+
+@pytest.fixture
+def mock_config():
+    """Create a mock config with telegram token."""
+    config = MagicMock(spec=Config)
+    config.telegram_bot_token = "test_token"
+    return config
+
+
+@pytest.fixture
+def mock_alfred():
+    """Create a mock Alfred engine."""
+    alfred = MagicMock(spec=Alfred)
+    alfred.chat = AsyncMock(
+        return_value=ChatResponse(content="Test response", model="kimi")
+    )
+    alfred.compact = AsyncMock(return_value="Compacted successfully")
+    return alfred
+
+
+@pytest.fixture
+def mock_update():
+    """Create a mock Telegram update with message."""
+    update = MagicMock()
+    update.message = MagicMock()
+    update.message.text = "Hello Alfred"
+    update.message.reply_text = AsyncMock()
+    return update
+
+
+@pytest.fixture
+def mock_context():
+    """Create a mock Telegram context."""
+    return MagicMock()
+
+
+@pytest.mark.asyncio
+async def test_message_delegates_to_alfred(mock_config, mock_alfred, mock_update, mock_context):
+    """Test that message handler delegates to Alfred.chat()."""
+    interface = TelegramInterface(mock_config, mock_alfred)
+
+    await interface.message(mock_update, mock_context)
+
+    mock_alfred.chat.assert_called_once_with("Hello Alfred")
+    mock_update.message.reply_text.assert_called_once_with("Test response")
+
+
+@pytest.mark.asyncio
+async def test_compact_delegates_to_alfred(mock_config, mock_alfred, mock_update, mock_context):
+    """Test that compact handler delegates to Alfred.compact()."""
+    interface = TelegramInterface(mock_config, mock_alfred)
+
+    await interface.compact(mock_update, mock_context)
+
+    mock_alfred.compact.assert_called_once()
+    mock_update.message.reply_text.assert_called_once_with("Compacted successfully")
+
+
+@pytest.mark.asyncio
+async def test_start_sends_greeting(mock_config, mock_alfred, mock_update, mock_context):
+    """Test that start handler sends greeting."""
+    interface = TelegramInterface(mock_config, mock_alfred)
+
+    await interface.start(mock_update, mock_context)
+
+    mock_update.message.reply_text.assert_called_once()
+    call_args = mock_update.message.reply_text.call_args[0][0]
+    assert "Alfred" in call_args
+
+
+@pytest.mark.asyncio
+async def test_message_handles_none_text(mock_config, mock_alfred, mock_context):
+    """Test that message handler handles None text gracefully."""
+    interface = TelegramInterface(mock_config, mock_alfred)
+
+    update = MagicMock()
+    update.message = MagicMock()
+    update.message.text = None
+    update.message.reply_text = AsyncMock()
+
+    await interface.message(update, mock_context)
+
+    mock_alfred.chat.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_message_handles_missing_message(mock_config, mock_alfred, mock_context):
+    """Test that message handler handles missing message gracefully."""
+    interface = TelegramInterface(mock_config, mock_alfred)
+
+    update = MagicMock()
+    update.message = None
+
+    await interface.message(update, mock_context)
+
+    mock_alfred.chat.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_message_surfaces_errors(mock_config, mock_alfred, mock_update, mock_context):
+    """Test that message handler surfaces errors to user."""
+    interface = TelegramInterface(mock_config, mock_alfred)
+    mock_alfred.chat.side_effect = Exception("API error")
+
+    with pytest.raises(Exception):
+        await interface.message(mock_update, mock_context)
+
+    mock_update.message.reply_text.assert_called()
+    call_args = mock_update.message.reply_text.call_args[0][0]
+    assert "Error" in call_args
+
+
+@pytest.mark.asyncio
+async def test_setup_creates_handlers(mock_config, mock_alfred):
+    """Test that setup creates all required handlers."""
+    interface = TelegramInterface(mock_config, mock_alfred)
+
+    # Mock Application.builder to avoid real API calls
+    mock_app = MagicMock()
+    mock_app.add_handler = MagicMock()
+
+    mock_builder = MagicMock()
+    mock_builder.token.return_value.build.return_value = mock_app
+
+    with pytest.MonkeyPatch.context() as m:
+        m.setattr("src.interfaces.telegram.Application.builder", lambda: mock_builder)
+
+        result = interface.setup()
+
+        assert result is mock_app
+        # Should have 3 handlers: start, compact, message
+        assert mock_app.add_handler.call_count == 3


### PR DESCRIPTION
## Description

Implements M5 Telegram Bot Integration as a thin interface layer that delegates to the core Alfred engine. Both Telegram and CLI interfaces are included, demonstrating the interchangeable interface architecture.

## Related PRD

Closes #15

## Changes Made

- [x] Add core Alfred engine (`src/alfred.py`) with `chat()` and `compact()` methods
- [x] Add Telegram interface (`src/interfaces/telegram.py`) with `/start`, `/compact`, and message handlers
- [x] Add CLI interface (`src/interfaces/cli.py`) for local testing
- [x] Add comprehensive tests (16 new tests, 75 total passing)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Testing

- [x] All tests pass (`uv run pytest`)
- [x] New tests added for new functionality

## Checklist

- [x] Self-review completed
- [x] Documentation updated (PRD status)
- [x] Type-safe throughout

## PRD Completion Evidence

- [x] `src/interfaces/telegram.py` - Telegram bot implementation
- [x] `src/interfaces/cli.py` - CLI interface (parallel implementation)
- [x] Async message handling
- [x] Delegation to core Alfred engine (not direct memory/context access)
- [x] Error handling with user feedback
- [x] Support for `/compact` command

## Additional Notes

The architecture follows the thin interface pattern - both Telegram and CLI delegate to the same Alfred engine, making interfaces interchangeable without changing core logic.