### PR TITLE
fix(forget): correct similarity lookup from dict by entry_id

### DIFF
--- a/src/tools/forget.py
+++ b/src/tools/forget.py
@@ -139,11 +139,12 @@ class ForgetTool(Tool):
 
             lines = [f"Found {len(results)} memories matching '{query}':\n"]
 
-            for entry, similarity in zip(results, similarities, strict=False):
+            for entry in results:
                 date_str = entry.timestamp.strftime("%Y-%m-%d")
                 preview = entry.content[:60]
                 if len(entry.content) > 60:
                     preview += "..."
+                similarity = similarities.get(entry.entry_id, 0.0)
                 match_pct = int(similarity * 100)
                 lines.append(f"  - [{date_str}] {preview}")
                 lines.append(f"    ID: {entry.entry_id} ({match_pct}% match)")

--- a/tests/tools/test_forget.py
+++ b/tests/tools/test_forget.py
@@ -88,7 +88,7 @@ class TestForgetTool:
         ]
         memories[0].entry_id = "abc123"
         memories[1].entry_id = "def456"
-        mock_memory_store.search.return_value = (memories, [0.9, 0.8], {})
+        mock_memory_store.search.return_value = (memories, {"abc123": 0.9, "def456": 0.8}, {})
 
         result = ""
         async for chunk in forget_tool.execute_stream(query="old project"):
@@ -112,7 +112,7 @@ class TestForgetTool:
             ),
         ]
         memories[0].entry_id = "long123"
-        mock_memory_store.search.return_value = (memories, [0.95], {})
+        mock_memory_store.search.return_value = (memories, {"long123": 0.95}, {})
 
         result = ""
         async for chunk in forget_tool.execute_stream(query="test"):

--- a/tests/tools/test_forget_new.py
+++ b/tests/tools/test_forget_new.py
@@ -220,7 +220,7 @@ class TestQueryMode:
         memories[0].entry_id = "abc123"
         memories[1].entry_id = "xyz789"
 
-        mock_memory_store.search.return_value = (memories, [0.95, 0.82], {})
+        mock_memory_store.search.return_value = (memories, {"abc123": 0.95, "xyz789": 0.82}, {})
 
         result = ""
         async for chunk in forget_tool.execute_stream(query="San Francisco"):
@@ -259,7 +259,7 @@ class TestQueryMode:
             ),
         ]
         memories[0].entry_id = "test-id-123"
-        mock_memory_store.search.return_value = (memories, [0.9], {})
+        mock_memory_store.search.return_value = (memories, {"test-id-123": 0.9}, {})
 
         result = ""
         async for chunk in forget_tool.execute_stream(query="test"):
@@ -529,7 +529,7 @@ class TestIntegrationScenarios:
             ),
         ]
         memories[0].entry_id = "sf-memory-id"
-        mock_memory_store.search.return_value = (memories, [0.95], {})
+        mock_memory_store.search.return_value = (memories, {"sf-memory-id": 0.95}, {})
         mock_memory_store.get_by_id.return_value = memories[0]
         mock_memory_store.delete_by_id.return_value = (True, "Memory deleted")
 


### PR DESCRIPTION
## Description

Fixes a bug in the forget tool where querying for memories to delete would fail with "invalid literal for int() with base 10" because the code was iterating over a dict's keys (hex string IDs) instead of looking up similarity values by entry_id.

## Related PRD

Fixes test failures - the bug was causing forget tool query mode to crash.

## Changes Made

- [x] Fix similarity lookup in forget.py _handle_query_mode() to use dict.get(entry_id) instead of zipping list with dict
- [x] Update test mocks in test_forget.py to return dict for similarities (matching MemoryStore.search return type)
- [x] Update test mocks in test_forget_new.py to return dict for similarities

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] All tests pass (uv run pytest - 293 passed)
- [x] Manual testing verified forget query mode works correctly

## Checklist

- [x] Code follows the project style guidelines (uv run ruff check src/)
- [x] Type checking passes (uv run mypy src/)
- [x] Self-review completed
- [x] No commented-out code
- [x] No print statements or debug logging left in production code