### PR TITLE
feat(prd-183): ship support learning v2 foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Do this once per conversation/session:
 2. Read `/workspace/alfred-prd/docs/ROADMAP.md`.
 3. Confirm once: `✅ Skills and parent PRD loaded`
 
-Only read `/home/node/.pi/skills/writing-clearly-and-concisely/SKILL.md` when the task is prose: docs, README text, commit messages, UI copy, reports, or other user-facing writing.
+Do not automatically read `/home/node/.pi/skills/writing-clearly-and-concisely/SKILL.md`. Use normal judgment for prose unless the user explicitly asks for writing help or the change clearly needs that extra guidance.
 
 Do not repeat these reads or the confirmation unless the session context has been reset.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,6 +309,41 @@ Do not use `sed`, regex replacement, or plain grep-based rewriting for code modi
 
 Use Playwright for development, debugging, and verification of browser behavior.
 
+### Render Mermaid diagrams to PNG (Web UI / docs)
+
+When a user asks to render a Mermaid diagram to a PNG, use **npx** (no install) per Option B.
+
+First-time setup (downloads a headless Chrome binary into the Puppeteer cache).
+
+Important: `mmdc` currently depends on `puppeteer-core` that expects a specific Chrome build, so install via the matching Puppeteer version:
+
+```bash
+npx -y puppeteer@23.11.1 browsers install chrome-headless-shell
+```
+
+Create a temporary Puppeteer config file for CI/containers (avoids sandbox issues). Write this JSON to `/tmp/mermaid-puppeteer-config.json`:
+
+```json
+{
+  "args": ["--no-sandbox", "--disable-setuid-sandbox"]
+}
+```
+
+Render (Markdown inputs with multiple Mermaid blocks will emit `...-1.png`, `...-2.png`, etc.):
+
+```bash
+mkdir -p /tmp/mermaid-out
+
+npx -y @mermaid-js/mermaid-cli@latest \
+  -p /tmp/mermaid-puppeteer-config.json \
+  -i docs/architecture/alfred-architecture-diagrams.md \
+  -o /tmp/mermaid-out/alfred-architecture-diagrams.png
+```
+
+Notes:
+- Prefer writing outputs to `/tmp/` unless the user explicitly wants committed assets.
+- If Puppeteer can’t find Chrome, re-run the `puppeteer@23.11.1 browsers install ...` step above.
+
 ### Viewing User Screenshots from Image Hosting Services
 
 Users often share screenshots via indirect links (gallery pages) rather than direct image URLs. To view these images:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -57,11 +57,15 @@ Alfred's durable markdown layer is built around:
 
 These files are always loaded and shape behavior every turn.
 
+Prompt fragments under `templates/prompts/` are small reusable supplements, not a second policy layer. The top-level files should stay compact and own the behavior-critical rules.
+
 ### Managed template sync
 
 `TemplateManager.reconcile_template()` keeps template sync workspace-scoped so one checkout cannot silently overwrite another.
 
-When an upstream template and a workspace file both change, the runtime should fail closed, mark the file as blocked for automatic sync, and write standard conflict markers instead of guessing. That blocked state should remain visible in `/context` and in the WebUI so operators can repair drift intentionally.
+When an upstream template and a workspace file both change, the runtime should fail closed, mark the file as blocked for automatic sync, and write standard conflict markers instead of guessing. The same rule applies to managed prompt fragments; if one of them conflicts, Alfred blocks the owning top-level context file instead of loading a partial prompt.
+
+That blocked state should remain visible in `/context`, in the persistent WebUI warning banner, and in the detailed WebUI context view so operators can repair drift intentionally.
 
 The canonical recovery flow lives in [Template Sync and Conflict Recovery](template-sync.md).
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -125,6 +125,7 @@ Its support-memory foundation shipped in PRD #167, adaptive support runtime and 
 | 168 | ✅ Adaptive Support Profile and Intervention Learning | Fixed support/relational registries, runtime support contracts, learning situations, bounded adaptation, and pattern-aware runtime policy (PRD #168) |
 | 169 | ✅ Reflection Reviews and Support Controls | Bounded inline reflection, `/support` inspection, typed correction flows, and `/review` weekly/on-demand review surfaces (PRD #169) |
 | 179 | ✅ Relational Support Operating Model | Formalized Alfred as one relational support system and aligned the shipped support-memory architecture under a shared operating model (PRD #179) |
+| 183 | ✅ Support Learning V2 Foundation | Replaced turn-centric learning with `SupportAttempt` → `OutcomeObservation` → `LearningCase`, shipped exact-scope v2 value-ledger auto-activation, real-ref persistence, deterministic work-state observations, and shared `/context` learned-state inspection payloads across TUI/Web UI (PRD #183) |
 
 ### In Progress / Next Up 🔨
 
@@ -137,7 +138,6 @@ Its support-memory foundation shipped in PRD #167, adaptive support runtime and 
 
 | # | Milestone | Description |
 |---|-----------|-------------|
-| 183 | Support Learning V2 - Case-Based Adaptation and Full Inspection | Replace turn-centric support learning with case-based adaptation, broader auto-learning, and full value inspection across `/context` and `/support` (PRD #183) |
 | 184 | Semantic Adjudication Runtime for Support Routing and Learning | Parent PRD for replacing heuristic support-routing seams with bounded LLM adjudication over rich symbolic runtime state, while keeping embeddings focused on retrieval (PRD #184) |
 | 185 | Shared Semantic Adjudication Contract and Symbolic Runtime Inputs | Define the shared prompt contract, symbolic input envelope, deterministic validators, fallback rules, and observability for support-runtime adjudicators (PRD #185) |
 | 186 | Semantic Session-Start Routing for Resume and Orientation | Replace phrase-list and substring fresh-session routing with bounded LLM adjudication over candidate arcs and orientation state (PRD #186) |

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,72 @@
+# Architecture Docs
+
+Use `docs/architecture/` for first-class architecture documents.
+
+`docs/ARCHITECTURE.md` is the top-level architecture overview and index.
+This directory holds the boundary-specific and design-specific architecture docs that the overview points to.
+
+## What belongs here
+
+Architecture docs are the durable source of truth for:
+- system shape
+- boundaries between subsystems
+- runtime contracts
+- integration seams
+- constraints and invariants
+- tradeoffs and chosen designs
+- migration and rollout shape for major refactors
+
+Use an architecture doc when the main artifact is a design decision or system boundary, not a feature delivery plan.
+
+## What does not belong here
+
+Do not use architecture docs as a substitute for:
+- PRDs
+- execution plans
+- task lists
+- release notes
+
+Those artifacts serve different purposes:
+- **PRD** = product intent, user-visible behavior, scope, milestones, and success criteria
+- **architecture doc** = system shape, boundaries, contracts, constraints, tradeoffs, and integration seams
+- **execution plan** = implementation phases, validation workflow, and task sequencing for a PRD slice
+
+## How to use this directory
+
+- Prefer updating an existing architecture doc when it already owns the boundary or contract
+- Create a new doc when the design deserves its own durable source of truth
+- Keep the filename short and stable, based on the system boundary or design topic
+- Link relevant architecture docs from PRDs that implement or depend on the design
+- Keep architecture docs aligned with shipped behavior, linked PRDs, execution plans, and relevant user-facing docs
+
+## Suggested filename pattern
+
+Use:
+- `docs/architecture/[slug].md`
+
+Examples:
+- `docs/architecture/support-runtime-adjudication.md`
+- `docs/architecture/webui-bootstrap-boundary.md`
+- `docs/architecture/support-learning-v2.md`
+
+## Suggested document shape
+
+A typical architecture doc should cover:
+- problem
+- goals and non-goals
+- current constraints
+- options considered
+- chosen design
+- ownership boundaries and contracts
+- migration or rollout plan
+- validation strategy
+- risks and open questions
+
+## Relationship to PRDs
+
+If a change needs both system design and product planning:
+1. create or update the architecture doc first
+2. create or update the PRD against that design
+3. link the PRD back to the architecture doc
+
+This keeps architecture rationale out of parent PRDs and keeps PRDs focused on delivery.

--- a/docs/architecture/alfred-architecture-diagrams.md
+++ b/docs/architecture/alfred-architecture-diagrams.md
@@ -1,0 +1,402 @@
+# Alfred Architecture Diagrams
+
+## 1. System context
+
+```mermaid
+flowchart TB
+    user[User]
+
+    subgraph interfaces[User-facing interfaces]
+        tui[TUI / CLI<br>Current]
+        webui[Web UI<br>Current]
+        telegram[Telegram<br>Current, less central]
+        croncli[Cron CLI / job management<br>Current]
+    end
+
+    subgraph runtime[Alfred runtime]
+        core[Alfred core runtime<br>Current]
+        context[Context assembly<br>Current]
+        prompts[Managed prompt files<br>Current<br>SYSTEM.md / AGENTS.md / SOUL.md / USER.md]
+        tools[Tool execution<br>Current]
+        llm[LLM provider orchestration<br>Current]
+        memory[Memory + support state<br>Current foundation]
+        support[Relational support runtime<br>Current foundation + planned expansion]
+        selfmodel[Runtime self-model / inspection<br>Current]
+    end
+
+    subgraph storage[Persistence and retrieval]
+        sqlite[(SQLite store<br>Current primary store)]
+        curated[Curated memory<br>Current]
+        archive[Session archive + tool provenance<br>Current]
+        supportmem[Support memory state<br>Current foundation]
+        embeddings[Embeddings provider<br>Current]
+    end
+
+    subgraph externals[External and local integrations]
+        provider[Chat model providers<br>Current: Kimi<br>Planned: multi-provider]
+        embedprov[Embedding providers<br>Current: OpenAI / local BGE]
+        jobs[Background cron execution<br>Current]
+    end
+
+    user --> tui
+    user --> webui
+    user --> telegram
+    user --> croncli
+
+    tui --> core
+    webui --> core
+    telegram --> core
+    croncli --> core
+
+    core --> context
+    context --> prompts
+    core --> tools
+    core --> llm
+    core --> memory
+    core --> support
+    core --> selfmodel
+
+    memory --> curated
+    memory --> archive
+    memory --> supportmem
+    curated --> sqlite
+    archive --> sqlite
+    supportmem --> sqlite
+    embeddings --> sqlite
+
+    llm --> provider
+    embeddings --> embedprov
+    jobs --> sqlite
+    jobs --> core
+```
+
+## 2. Current runtime container view
+
+```mermaid
+flowchart LR
+    subgraph interfaces[Interfaces]
+        cli[TUI / CLI]
+        web[Web UI]
+        tg[Telegram]
+        cron[Cron daemon / cron commands]
+    end
+
+    subgraph app[Application runtime]
+        config[Config loading<br>alfred.config]
+        core[Core orchestration<br>Current]
+        session[Session management<br>Current]
+        ctx[ContextLoader / context assembly<br>Current]
+        template[TemplateManager / sync<br>Current]
+        tools[Tool registry + execution<br>Current]
+        stream[Streaming response loop<br>Current]
+        inspect["/context + self-model surfaces<br>Current"]
+    end
+
+    subgraph intelligence[Intelligence services]
+        chat[LLMFactory / provider chat + stream<br>Current]
+        embed[Embedding provider<br>Current]
+        policy[Support policy compiler<br>Current foundation]
+        adjudication[Semantic adjudication<br>Planned]
+    end
+
+    subgraph data[Data services]
+        sqlite[(SQLite)]
+        cur[Curated memory]
+        sess[Session archive]
+        sup[Support memory / profile / episodes]
+        crondata[Cron data]
+    end
+
+    cli --> core
+    web --> core
+    tg --> core
+    cron --> core
+
+    config --> core
+    core --> session
+    core --> ctx
+    core --> template
+    core --> tools
+    core --> stream
+    core --> inspect
+
+    ctx --> chat
+    ctx --> cur
+    ctx --> sess
+    ctx --> sup
+    core --> policy
+    policy -. planned richer judgments .-> adjudication
+    chat --> sqlite
+    embed --> sqlite
+
+    cur --> sqlite
+    sess --> sqlite
+    sup --> sqlite
+    crondata --> sqlite
+```
+
+## 3. Current turn flow
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as User
+    participant I as Interface
+    participant C as Core runtime
+    participant X as Context loader
+    participant M as Memory/support retrieval
+    participant P as Support policy compiler
+    participant L as LLM provider
+    participant T as Tool executor
+    participant S as SQLite store
+
+    U->>I: Send message / command
+    I->>C: Normalized request
+    C->>X: Assemble context
+    X->>S: Load managed files state / sync info
+    X->>M: Fetch relevant memory + support state
+    M->>S: Query curated memory, session archive, support data
+    M-->>X: Retrieved context inputs
+    X-->>C: Assembled prompt context
+
+    C->>P: Resolve support behavior contract
+    P->>S: Load scoped support/relational values
+    P-->>C: Behavior contract
+
+    C->>L: Start streaming chat
+    alt Tool call requested
+        L-->>C: Tool call
+        C->>T: Execute tool
+        T->>S: Persist tool outcomes if needed
+        T-->>C: Tool result
+        C->>L: Continue with tool result
+    end
+    L-->>C: Stream response chunks
+    C->>S: Persist session messages + tool provenance
+    C-->>I: Stream output
+    I-->>U: Visible response
+```
+
+## 4. Current memory and continuity architecture
+
+```mermaid
+flowchart TB
+    subgraph alwayson[Always-loaded durable context]
+        system[SYSTEM.md]
+        agents[AGENTS.md]
+        soul[SOUL.md]
+        usermd[USER.md]
+    end
+
+    subgraph memorylayers[Memory layers]
+        curated[Curated memory<br>Current]
+        archive[Session archive<br>Current]
+        episodes[Support episodes + evidence refs<br>Current]
+        operational[Life domains / operational arcs / work state<br>Current]
+        situations[ArcSituation / GlobalSituation<br>Current]
+        profile[Support profile values<br>Current]
+        patterns[Patterns / review state<br>Current foundation, expanding]
+    end
+
+    subgraph retrieval[Runtime retrieval order]
+        currentturn[Current conversation]
+        supportfirst[Operational-first retrieval seam<br>Current]
+        inject[Auto-injected curated memory<br>Current]
+        fallback[Archive fallback / provenance search<br>Current]
+    end
+
+    currentturn --> alwayson
+    alwayson --> supportfirst
+    supportfirst --> operational
+    operational --> situations
+    supportfirst --> episodes
+    supportfirst --> profile
+    supportfirst --> patterns
+    supportfirst --> inject
+    inject --> curated
+    supportfirst --> fallback
+    fallback --> archive
+```
+
+## 5. Current support runtime vs planned support runtime
+
+```mermaid
+flowchart TB
+    subgraph current[Current support runtime foundation]
+        assess[Need / response-mode assessment<br>Current heuristic foundation]
+        resolve[Resolve support + relational values<br>Current]
+        compile[Compile behavior contract<br>Current]
+        intervene[Choose intervention family<br>Current]
+        attempt[Record support attempt<br>Current]
+        inspect[Inspection and review surfaces<br>Current foundation]
+    end
+
+    subgraph planned[Planned richer support runtime]
+        semantic[Semantic adjudication over symbolic state<br>Planned]
+        caselrn[Case-based learning v2<br>Planned]
+        stance[Semantic relational-state + stance adjudication<br>Planned]
+        extraction[Natural-language observation extraction<br>Planned]
+        surfacing[Pattern + relational surfacing adjudication<br>Planned]
+    end
+
+    assess --> resolve --> compile --> intervene --> attempt --> inspect
+
+    semantic -. replaces heuristic seams .-> assess
+    semantic -. enriches subject / need / session routing .-> resolve
+    caselrn -. updates learned values and cases .-> resolve
+    stance -. applies bounded stance deltas .-> compile
+    extraction -. produces typed observations .-> caselrn
+    surfacing -. controls when to explain or surface .-> inspect
+```
+
+## 6. Planned learning and evidence architecture
+
+```mermaid
+flowchart LR
+    transcript[Transcript sessions + message refs<br>Current raw archive]
+    toolprov[Tool provenance<br>Current]
+    feedback[User corrections / feedback / support controls<br>Current foundation]
+    transitions[Operational transitions<br>Current foundation]
+
+    subgraph substrate[Shared evidence substrate]
+        attempt[SupportAttempt<br>Current foundation]
+        observation[OutcomeObservation<br>Planned richer extraction]
+        lcase[LearningCase<br>Planned case-based core]
+    end
+
+    subgraph models[Symbolic models]
+        operational[Operational symbolic world<br>Current foundation + planned richer patterns]
+        relational[Relational symbolic world<br>Current foundation + planned richer stance semantics]
+        handles[Cross-domain handles / ownership / dedupe<br>Planned]
+    end
+
+    subgraph outputs[User-visible and runtime outputs]
+        values[Scoped support/relational values<br>Current]
+        review[Review cards / inspection / correction<br>Current foundation + planned expansion]
+        runtime[Effective runtime contract<br>Current]
+    end
+
+    transcript --> attempt
+    toolprov --> attempt
+    feedback --> observation
+    transitions --> observation
+    attempt --> lcase
+    observation --> lcase
+
+    lcase --> operational
+    lcase --> relational
+    operational -. planned shared identity layer .-> handles
+    relational -. planned shared identity layer .-> handles
+
+    operational --> values
+    relational --> values
+    values --> runtime
+    handles --> review
+    operational --> review
+    relational --> review
+```
+
+## 7. Current storage architecture
+
+```mermaid
+flowchart TB
+    subgraph producers[Writers]
+        runtime[Runtime conversation loop]
+        tools[Tools]
+        cron[Cron system]
+        memoryops[Memory/support updaters]
+    end
+
+    subgraph store[Unified persistence]
+        sqlite[(SQLite store<br>Current source of truth)]
+    end
+
+    subgraph logical[Logical datasets]
+        sessions[Sessions + messages]
+        toolcalls[Tool calls / provenance]
+        curated[Curated memory]
+        support[Support memory objects<br>Episodes / arcs / domains / profile values]
+        cronjobs[Cron jobs + history]
+        vectors[Embeddings / vector search backing]
+    end
+
+    runtime --> sqlite
+    tools --> sqlite
+    cron --> sqlite
+    memoryops --> sqlite
+
+    sqlite --> sessions
+    sqlite --> toolcalls
+    sqlite --> curated
+    sqlite --> support
+    sqlite --> cronjobs
+    sqlite --> vectors
+```
+
+## 8. Interface and transport view
+
+```mermaid
+flowchart LR
+    subgraph local[Local-first surfaces]
+        tui[TUI / CLI<br>Current]
+        web[Web UI<br>Current]
+        cronui[Cron commands<br>Current]
+    end
+
+    subgraph optional[Optional / secondary surfaces]
+        tg[Telegram<br>Current, secondary]
+    end
+
+    subgraph services[Runtime services]
+        app[Shared Alfred runtime]
+        ws[WebSocket / live UI state<br>Current foundation, improving]
+        notifications[Notification paths<br>Current foundation]
+    end
+
+    tui --> app
+    web --> ws
+    ws --> app
+    cronui --> app
+    tg --> app
+    app --> notifications
+```
+
+## 9. Planned architecture trajectory map
+
+```mermaid
+flowchart TD
+    past[Memory-augmented assistant<br>Past center of gravity]
+    current[Local-first assistant with support-memory foundation<br>Current]
+    next1[Relational support runtime with bounded policy compiler<br>Current + in progress]
+    next2[Semantic adjudication over symbolic runtime state<br>Planned]
+    next3[Case-based learning, richer inspection, and cross-domain coordination<br>Planned]
+    target[Persistent relational support system with operational intelligence<br>Target]
+
+    past --> current --> next1 --> next2 --> next3 --> target
+```
+
+## 10. Ownership map
+
+```mermaid
+flowchart TB
+    subgraph markdown[Managed markdown truth]
+        sys[SYSTEM.md<br>Owns support operating model / retrieval order / promotion rules]
+        ag[AGENTS.md<br>Owns execution and tool behavior rules]
+        so[SOUL.md<br>Owns Alfred identity / voice / relational posture]
+        us[USER.md<br>Owns explicit user-confirmed durable truths]
+    end
+
+    subgraph runtime[Structured runtime truth]
+        supportstate[Support memory<br>Owns active operational continuity]
+        profile[Support learning / profile state<br>Owns effective support and relational adaptation]
+        curated[Curated memory<br>Owns reusable remembered facts]
+        archive[Session archive<br>Owns raw provenance and recall]
+    end
+
+    sys --> supportstate
+    ag --> supportstate
+    so --> profile
+    us --> curated
+    archive --> supportstate
+    archive --> profile
+```

--- a/docs/design/cross-domain-learning-ownership-and-surfacing.md
+++ b/docs/design/cross-domain-learning-ownership-and-surfacing.md
@@ -1,0 +1,328 @@
+# Architecture: Cross-Domain Learning (Shared Substrate, Separate Symbolic Worlds)
+
+## Status
+
+Design direction. This document records what we want at the architecture level, so we can write smaller PRDs without re-arguing first principles.
+
+## Summary
+
+We want Alfred to learn across domains (operational support, relational support, and biographical memory) without:
+- forcing a false dichotomy (“operational *or* relational”) when many patterns span both
+- collapsing everything into one mushy ontology
+- surfacing the same underlying insight multiple times in different voices
+
+The core move is:
+
+1. **Shared learning substrate** (grounded evidence → attempts/observations → cases)
+2. **Separate domain symbolic worlds** (operational model vs relational model: different objects, validators, promotion rules)
+3. **A coordination layer** for:
+   - cross-domain identity linking
+   - primary ownership
+   - surfacing deduplication
+
+This is *not* “one system and multiple views into the same domain model.”
+It is “one substrate and multiple compiled symbolic models.”
+
+---
+
+## 1) Domains and boundaries
+
+### Operational domain (symbolic world)
+Owns models like:
+- arcs, tasks, blockers, decisions, open loops
+- operational patterns (e.g. recurring blocker, calibration gap)
+- operational surfacing and reflection guidance
+
+Primary question: **“What is happening in work-state and how do we move?”**
+
+### Relational domain (symbolic world)
+Owns models like:
+- relational stance dimensions + stance deltas
+- relational preferences/boundaries
+- rupture/repair signals and trust-sensitive dynamics
+- relational surfacing and meta-explanation
+
+Primary question: **“How should Alfred show up, and what keeps trust intact?”**
+
+### Biographical / narrative lane
+Biographical facts and life history belong in **curated memory** (and USER.md when truly always-on). They are not the same artifact type as operational/relational learning.
+
+Primary question: **“What durable explicit truths about the user should be recallable later?”**
+
+---
+
+## 2) The shared substrate (the part we unify)
+
+We unify the *evidence and learning lifecycle*, not the domain ontology.
+
+### 2.1 Evidence atoms
+All learning must ultimately ground in evidence atoms with provenance.
+
+Evidence sources include:
+- transcript spans (message_id + exact quote)
+- explicit user feedback / corrections
+- support-control actions (/support flows)
+- operational transitions (task completed, blocker narrowed, decision resolved)
+
+Invariants:
+- evidence must have real session/message refs (no fabricated placeholders)
+- quotes must be exact substrings of source messages
+
+### 2.2 Attempts → observations → cases
+We want one shared lifecycle (as in PRD #183):
+- `SupportAttempt`: what Alfred tried
+- `OutcomeObservation`: what happened after
+- `LearningCase`: the join of attempt + observations + operational transitions
+
+Invariants:
+- extractors emit observations; **they do not promote** values/patterns directly
+- promotion/demotion remains controlled and inspectable
+
+---
+
+## 3) Separate symbolic worlds (the part we do *not* unify)
+
+Each domain defines:
+- its own **ontology** (pattern types, state objects)
+- its own **validators**
+- its own **promotion rules**
+- its own **surfacing adjudicator**
+
+This is intentional: operational and relational are different symbolic languages.
+
+### Example: same underlying phenomenon, two projections
+User says: “I shut down when you push me.”
+
+- Relational projection (primary): pressure boundary / rupture risk / stance constraint
+- Operational projection (secondary): planning tactic constraint; a “pressure causes stall” blocker pattern
+
+Both can be true without forcing one schema.
+
+---
+
+## 4) Cross-domain identity without a single ontology
+
+To avoid duplicated “same idea” artifacts, we introduce a thin cross-domain linking object.
+
+### 4.1 Pattern handle (cross-domain identity)
+A `PatternHandle` is not a domain model. It is a stable identity for “this underlying learned thing.”
+
+Policy:
+- **Every candidate pattern and every promoted/confirmed pattern has a handle** (even purely single-domain patterns).
+- **Observations do not mint handles.** Observations remain substrate evidence; handles begin at the candidate-pattern artifact layer.
+- Cross-domain patterns are represented as **one handle with multiple projections**.
+
+Suggested fields:
+- `handle_id`
+- `canonical_label` (short human name)
+- `evidence_ids[]` (**canonical shared grounding lives on the handle**)
+- `projections[]`: list of `(domain, domain_pattern_id)`
+
+A handle may have:
+- one projection (purely operational *or* purely relational)
+- multiple projections (cross-domain)
+
+### 4.2 Ownership
+Each handle has **one primary domain**.
+
+Ownership means:
+- who gets first-class modeling responsibility
+- who has the right to **introduce** the pattern to the user
+
+Secondary domains may:
+- reference the handle
+- apply it as a constraint
+- elaborate when the user explicitly asks from that domain
+
+### 4.3 Handle linking and non-destructive dedupe
+
+A handle only exists once a **candidate pattern** exists. When the system is about to create a new candidate pattern, it must decide:
+
+- **attach**: add a new domain projection onto an existing handle
+- **create**: create a new handle with a new candidate projection
+
+Policy:
+- **Be conservative.** False merges are worse than duplicates.
+- **Never destructively merge handles automatically.** If uncertain, create a new handle.
+- Allow the system to record non-destructive hints such as `possible_duplicate_of=[handle_id...]` for later review.
+- The user can prune or merge later through inspection/control surfaces.
+
+---
+
+## 5) Lane assignment (creating projections + choosing a primary)
+
+We treat “operational vs relational” as two decisions:
+
+1. **Projection decision:** which domain(s) get a projection?
+2. **Primary decision:** if multiple projections exist, which domain is primary?
+
+### 5.1 Projection decision rules
+Create a projection in a domain when:
+- the evidence supports a valid domain object *and*
+- storing it in that domain will change future behavior in that domain
+
+Otherwise:
+- keep it as evidence/candidate until additional cases exist
+
+### 5.2 Primary decision tie-breakers (proposed)
+Primary should be chosen by *intervention locus and risk*, not metaphysics.
+
+Ordered tie-breakers:
+1. **Explicit user framing**
+   - user is talking about boundary/tone/trust → relational
+   - user is talking about progress/blockers/structure → operational
+2. **Trust/rupture risk if wrong**
+   - if wrong classification risks misattunement → relational
+3. **Action locus**
+   - lever is stance/how Alfred shows up → relational
+   - lever is plan/structure/next step → operational
+4. **Stability / existing ownership**
+   - preserve existing primary unless new evidence forces change
+
+User override should exist (explicit command or extracted meta-request).
+
+---
+
+## 6) Surfacing coordination (dedupe across domains)
+
+Surfacing is a UX event. We need one coordinating contract.
+
+### 6.1 Surfacing event log
+Maintain a shared log of surfacing events:
+- `handle_id`
+- `surfaced_by_domain`
+- `surface_kind` (pattern surfacing, stance explanation, boundary acknowledgment)
+- `surface_level` (implicit/compact/rich)
+- timestamp
+
+### 6.2 Introduction rights
+- Only the **primary domain** may do *fresh surfacing* (“here’s a pattern I’m noticing”).
+- Secondary domains may reference (“as we discussed…”) but should not re-introduce.
+
+### 6.3 Cooldowns
+After a fresh surfacing event:
+- apply a cooldown window during which no other domain may freshly surface the same handle
+
+### 6.4 Turn budgets
+Default budgets:
+- 0–1 fresh surfacing items per turn
+- allow 2 only when the user explicitly asks for reflection / meta-explanation
+
+---
+
+## 7) Inspection and user control
+
+This architecture only works if users can inspect and correct it.
+
+### 7.1 Handle-first inspection
+
+Principle:
+- Users operate on **PatternHandles first**.
+- Domain projections stay separately inspectable, but the handle is the coordination unit.
+
+Minimum inspection surfaces:
+
+- `/context`
+  - compact view of **effective runtime state**
+  - includes active handles (and their projections) that are currently influencing behavior
+  - shows `primary_domain` and the "why" (evidence count / last update event / scope)
+
+- `/support patterns`
+  - list PatternHandles with filters:
+    - status: `active`, `candidate`, `confirmed`, `rejected`, `retired`, `archived`
+    - domain: `operational`, `relational`, `any`
+    - scope: `global`, `context:<x>`, `arc:<id>`
+
+- `/support pattern <handle_id>`
+  - shared fields: label, primary domain, scope, canonical evidence refs, surfacing state
+  - projections present: operational and/or relational summaries
+  - duplicate links: `duplicate_of`, `possible_duplicate_of[]`
+
+- `/support pattern <handle_id> operational|relational`
+  - drills into the chosen domain projection’s symbolic world and status
+
+### 7.2 Correction actions (projection-scoped vs handle-scoped)
+
+**Projection-scoped actions** (because operational and relational have different semantics):
+- confirm/reject/retire a specific projection
+  - e.g. `/support pattern <id> confirm operational`
+
+**Handle-scoped actions** (because they govern cross-domain coordination and UX):
+- set ownership:
+  - `/support pattern <id> set-primary operational|relational`
+- control surfacing:
+  - `/support pattern <id> suppress [--until <date>]`
+  - `/support pattern <id> allow-surfacing`
+- mark duplicates (see below)
+
+### 7.3 Duplicate handling (single-canonical, non-destructive)
+
+We treat duplicate handling as **archival + reinforcement**, not destructive merging.
+
+#### 7.3.1 `duplicate-of` operation
+
+Command:
+- `/support pattern <handle_id_A> duplicate-of <handle_id_B>`
+
+Semantics:
+- `A` becomes **archived as a duplicate**:
+  - never loaded into effective runtime state
+  - never surfaced
+  - hidden from default lists (but visible via `archived` filters)
+  - always inspectable (no deletion)
+- `B` becomes the **canonical handle**.
+- **Projection inheritance:** `B` inherits any missing projections from `A` (union of symbolic representations).
+- **Reinforcement:** `B`’s evidence set / case counts / contradiction counts incorporate `A`’s evidence via linking (no rewriting required).
+
+Policy:
+- conservative by default; the system should not perform this automatically.
+- user-driven and reversible.
+
+#### 7.3.2 Single-canonical constraint
+
+Rules:
+- each handle may have at most one `duplicate_of_handle_id`
+- prevent cycles
+- if chains exist (A → B → C), the system should compress them so A points directly to C
+
+Undo:
+- `/support pattern <handle_id_A> unduplicate`
+  - restores A to normal visibility/load rules
+  - **does not subtract** any previously contributed reinforcement/evidence from the canonical handle
+
+---
+
+## 8) How this maps to the existing PRD stack
+
+This doc is intended to align and de-conflict these PRDs (not replace them):
+
+Shared substrate:
+- PRD #183 (attempt → observation → case)
+
+Operational symbolic world + surfacing:
+- PRD #190 (pattern surfacing adjudication)
+
+Relational symbolic world + extraction + surfacing:
+- PRD #196 (relational preference/boundary extraction)
+- PRD #197 (relational meta-explanation surfacing)
+
+What’s missing (candidate future PRD):
+- a cross-domain **handle + ownership + surfacing coordination** contract
+
+---
+
+## 9) Open questions (to decide explicitly)
+
+1. Secondary projection policy:
+   - when do we add a second (or third) domain projection to an existing handle?
+   - do we do it whenever evidence supports it, or only when explicitly adjudicated as cross-domain?
+   - do we allow automatic secondary projections within a single case when evidence overlap is high (same case_id/evidence_ids)?
+
+2. Primary decision mechanism:
+   - deterministic rules only, or bounded semantic adjudication (with strict validators + fallback)?
+
+3. User override UX:
+   - commands only, natural language extraction, or both?
+
+4. Relationship state richness:
+   - does the relational symbolic world need explicit long-lived objects like `RelationshipState` / rupture-repair records, or do we keep it as values + patterns only?

--- a/docs/template-sync.md
+++ b/docs/template-sync.md
@@ -14,6 +14,8 @@ The sync store is lazy-loaded. Alfred reads it when template reconciliation need
 
 When Alfred starts or reconnects, it reconciles each managed template through `TemplateManager.reconcile_template()`.
 
+That same contract now applies to managed prompt fragments under `templates/prompts/`, not just the top-level always-loaded files.
+
 That reconciliation compares three things:
 
 1. the current template file
@@ -25,6 +27,8 @@ If the workspace still matches the saved base snapshot, Alfred fast-forwards the
 If both the template and the workspace changed, Alfred writes standard git conflict markers into the workspace file and marks the file conflicted.
 
 If the workspace already contains conflict markers, Alfred keeps the file blocked and leaves the markers in place. The app stays up, but the affected context file is unavailable until the conflict is fixed. This keeps the path fail closed.
+
+If the conflicted file is a managed prompt fragment such as `prompts/voice.md`, Alfred blocks the owning top-level context file instead of half-loading it with drifted fragments.
 
 ## What a conflict looks like
 
@@ -44,7 +48,11 @@ Use those markers as the source of truth. Do not replace them with custom prose 
 
 A conflicted file is blocked from context loading. The `/context` command shows the blocked files and the warning text directly.
 
-The WebUI uses the same warning payload, so the conflict is visible in the browser too. You do not need to inspect logs to see that a file is blocked.
+The WebUI uses the same warning payload in two places:
+- a persistent warning banner from `status.update`
+- the detailed `/context` view
+
+You do not need to inspect logs to see that a file is blocked, but the runtime also logs conflict creation, blocked loads, and clean resolution.
 
 The warning remains visible until Alfred sees a clean file again.
 

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -443,6 +443,11 @@ Sent in response to `/context` command.
 
 `support_state.enabled` is `false` when the support inspection runtime is unavailable. When enabled, `support_state` also includes `active_runtime_state`, `learned_state`, `active_domains`, and `active_arcs`.
 
+`support_state.learned_state` includes additional v2 learning-inspection fields:
+- `value_ledger_entries`: bounded list of v2 value-ledger entries (support + relational)
+- `value_ledger_summary`: `{ total, counts_by_status, counts_by_registry }`
+- `recent_ledger_update_events`: bounded list of recent v2 ledger update events
+
 ---
 
 ### `chat.started`

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -624,7 +624,19 @@ Sent periodically during streaming to report current status.
     "cacheReadTokens": 0,
     "reasoningTokens": 0,
     "queueLength": 0,
-    "isStreaming": true
+    "isStreaming": true,
+    "contextStatus": {
+      "blockedContextFiles": ["SOUL.md"],
+      "conflictedContextFiles": [
+        {
+          "id": "soul",
+          "name": "soul",
+          "label": "SOUL.md",
+          "reason": "Conflicted managed prompt fragment prompts/voice.md blocks SOUL.md"
+        }
+      ],
+      "warnings": ["Disabled sections: TOOLS"]
+    }
   }
 }
 ```
@@ -642,8 +654,9 @@ Sent periodically during streaming to report current status.
 | `reasoningTokens` | `number` | Tokens used for reasoning |
 | `queueLength` | `number` | Number of queued messages |
 | `isStreaming` | `boolean` | Whether LLM is currently streaming |
+| `contextStatus` | `object` | Lightweight context-health snapshot for persistent Web UI warnings: blocked files, structured conflict records, and warning strings |
 
-**Usage:** This message is used to update the status bar in the UI with real-time token counts and streaming state.
+**Usage:** This message is used to update the status bar in the UI with real-time token counts and streaming state, and to keep the persistent Web UI context-warning banner in sync.
 
 ---
 

--- a/prds/183-support-learning-v2-case-based-adaptation-and-full-inspection.md
+++ b/prds/183-support-learning-v2-case-based-adaptation-and-full-inspection.md
@@ -688,10 +688,10 @@ This PRD is successful when:
 - [ ] **Milestone 1: V2 learning schema and storage contract landed**  
       Add the new attempt, observation, case, value-status, pattern-status, and update-event structures with explicit persistence invariants.
 
-- [ ] **Milestone 2: Reply-time runtime writes `SupportAttempt` records with real refs**  
+- [x] **Milestone 2: Reply-time runtime writes `SupportAttempt` records with real refs**  
       Alfred persists what it tried using real session and message references and never falls back to fake runtime ids.
 
-- [ ] **Milestone 3: Outcome observation pipeline captures operational evidence**  
+- [x] **Milestone 3: Outcome observation pipeline captures operational evidence**  
       Alfred records post-reply outcome observations from work-state transitions.
 
       Note: conversational / semantic observation extraction (explicit feedback, next-turn signals, etc.) is out-of-scope for PRD #183 and owned by **PRD #189**.
@@ -699,15 +699,16 @@ This PRD is successful when:
       Sub-milestones:
       - [x] **Milestone 3A:** Deterministic `work_state_transition` observations from public SQLite work-state seams, linked to the latest matching `SupportAttempt` by `active_arc_id`.
 
-- [ ] **Milestone 4: Case finalization and scoring replace turn-centric promotion logic**  
+- [x] **Milestone 4: Case finalization and scoring replace turn-centric promotion logic**  
       Alfred promotes and demotes from completed `LearningCase` records instead of thin per-turn snapshots.
 
       Sub-milestones:
       - [x] **Milestone 4A:** Deterministic case finalization + scoring from stored `SupportAttempt` + `OutcomeObservation` bundles.
-      - [ ] **Milestone 4B:** Runtime cutover so promotion/adaptation reads finalized cases as the primary learning unit.
+      - [x] **Milestone 4B:** Runtime cutover so promotion/adaptation reads finalized cases as the primary learning unit.
             Sub-milestones:
             - [x] **Milestone 4B.1:** Runtime value resolution prefers v2 value-ledger entries (`active_auto` / `confirmed`) over legacy v1 support-profile values.
             - [x] **Milestone 4B.2:** Remove or fully retire turn-centric bounded adaptation (`LearningSituation`) so case-derived learning is the primary driver.
+            - [x] **Milestone 4B.3:** Apply v2 case-learning automatically from operational observations (work-state transitions).
 
 - [ ] **Milestone 5: Less-conservative scoped adaptation ships for support and relational values**  
       Arc, context, and global learning work with lower thresholds, contradiction tracking, and explicit auto-activation rules.
@@ -838,6 +839,7 @@ Additional required verification for this PRD:
 | 2026-04-07 | Alfred should be less conservative about what it learns and when it activates it | The user prefers a more adaptive and somewhat overzealous system that can be inspected and corrected later |
 | 2026-04-07 | Both support values and relational values may auto-activate when evidence is strong enough | The user explicitly prefers a less conservative adaptation model, including relational stance changes |
 | 2026-04-09 | PRD #183 owns relational value ledger and activation semantics, not relational dimension meaning or live stance behavior | This keeps the shared learning architecture in #183 while deferring relational runtime semantics to PRDs #192 and #193 |
+| 2026-04-09 | Work-state transition observations should trigger case finalization + v2 ledger updates in the same SQLite transaction | This makes the v2 learning pipeline run end-to-end deterministically from operational evidence without cross-connection visibility bugs |
 | 2026-04-07 | Visibility and correction are the main safety boundary for aggressive learning | The user wants Alfred to learn more, provided the system can be interrogated and changed |
 | 2026-04-07 | `/context` should show effective runtime state, while `/support` must be able to show all values and traces | Compact active-state inspection and full-ledger inspection serve different jobs |
 | 2026-04-07 | Cross-arc learning is allowed, with higher thresholds than arc-local promotion | Generalization is desired, but should still be scope-aware |

--- a/prds/183-support-learning-v2-case-based-adaptation-and-full-inspection.md
+++ b/prds/183-support-learning-v2-case-based-adaptation-and-full-inspection.md
@@ -691,12 +691,13 @@ This PRD is successful when:
 - [ ] **Milestone 2: Reply-time runtime writes `SupportAttempt` records with real refs**  
       Alfred persists what it tried using real session and message references and never falls back to fake runtime ids.
 
-- [ ] **Milestone 3: Outcome observation pipeline captures conversational and operational evidence**  
-      Alfred records post-reply outcome observations from user feedback, next-turn signals, and work-state transitions.
+- [ ] **Milestone 3: Outcome observation pipeline captures operational evidence**  
+      Alfred records post-reply outcome observations from work-state transitions.
+
+      Note: conversational / semantic observation extraction (explicit feedback, next-turn signals, etc.) is out-of-scope for PRD #183 and owned by **PRD #189**.
 
       Sub-milestones:
       - [x] **Milestone 3A:** Deterministic `work_state_transition` observations from public SQLite work-state seams, linked to the latest matching `SupportAttempt` by `active_arc_id`.
-      - [ ] **Milestone 3B:** Conversational / semantic observation extraction (explicit feedback, next-turn signals, etc.).
 
 - [ ] **Milestone 4: Case finalization and scoring replace turn-centric promotion logic**  
       Alfred promotes and demotes from completed `LearningCase` records instead of thin per-turn snapshots.

--- a/prds/183-support-learning-v2-case-based-adaptation-and-full-inspection.md
+++ b/prds/183-support-learning-v2-case-based-adaptation-and-full-inspection.md
@@ -717,11 +717,11 @@ This PRD is successful when:
 
       Sub-milestones:
       - [x] **Milestone 6A.1 (Web UI-only foundation):** `/context` support inspection snapshot includes v2 `value_ledger_entries`, `value_ledger_summary`, and `recent_ledger_update_events`.
-      - [ ] **Milestone 6A.2 (Web UI):** Web UI renders the v2 value ledger inside `context-viewer` and the websocket protocol docs are updated.
+      - [x] **Milestone 6A.2 (Web UI):** Web UI renders the v2 value ledger inside `context-viewer` and the websocket protocol docs are updated.
             Sub-milestones:
             - [x] **Milestone 6A.2a (Python):** `/context` payload forwards `value_ledger_entries`, `value_ledger_summary`, and `recent_ledger_update_events` under `support_state.learned_state`.
             - [x] **Milestone 6A.2b (Docs):** websocket protocol docs describe the new v2 support learned-state fields.
-            - [ ] **Milestone 6A.2c (Web UI):** `context-viewer` renders the v2 value ledger and is covered by a Playwright browser test.
+            - [x] **Milestone 6A.2c (Web UI):** `context-viewer` renders the v2 value ledger and is covered by a Playwright browser test.
       - [ ] **Milestone 6B:** Full `/support` inspection surfaces + cross-surface (TUI/Web UI) parity for full-ledger inspection.
 
 - [ ] **Milestone 7: V1 learning path is removed and docs are aligned**  

--- a/prds/183-support-learning-v2-case-based-adaptation-and-full-inspection.md
+++ b/prds/183-support-learning-v2-case-based-adaptation-and-full-inspection.md
@@ -809,3 +809,4 @@ Additional required verification for this PRD:
 | 2026-04-07 | Cross-arc learning is allowed, with higher thresholds than arc-local promotion | Generalization is desired, but should still be scope-aware |
 | 2026-04-07 | Do not preserve backward compatibility for v1 learning data if it blocks a cleaner v2 runtime | The repo is in beta, and the current learning rows are too thin to justify migration-heavy preservation |
 | 2026-04-07 | Support-learning persistence must use real session ids and should skip or defer writes rather than invent placeholders | The runtime contract must stay storage-safe and explainable |
+| 2026-04-07 | Milestone 3 should start with deterministic `work_state_transition` observations before conversational or semantic extraction | This keeps the first observation lane inside PRD #183 and defers sibling semantic PRDs until later milestones |

--- a/prds/183-support-learning-v2-case-based-adaptation-and-full-inspection.md
+++ b/prds/183-support-learning-v2-case-based-adaptation-and-full-inspection.md
@@ -2,7 +2,7 @@
 
 **GitHub Issue**: [#183](https://github.com/jeremysball/alfred/issues/183)  
 **Priority**: High  
-**Status**: Draft  
+**Status**: In Progress  
 **Created**: 2026-04-07  
 **Author**: Agent
 
@@ -413,6 +413,12 @@ Representative dimensions:
 #### Relational values
 Relational values may also auto-activate when evidence is strong enough.
 
+Boundary note:
+- this PRD owns the shared ledger, status, promotion, activation, and inspection rules for relational values
+- it does **not** own the product meaning of relational dimensions or how they compile into live stance behavior
+- PRD #192 owns the relational runtime architecture, and PRD #193 owns the product semantics and compiler contract for dimensions such as `candor`, `challenge`, and `warmth`
+- the list below is illustrative and should stay generic unless a child relational PRD explicitly owns the behavioral meaning
+
 Representative dimensions:
 - `candor`
 - `challenge`
@@ -688,14 +694,31 @@ This PRD is successful when:
 - [ ] **Milestone 3: Outcome observation pipeline captures conversational and operational evidence**  
       Alfred records post-reply outcome observations from user feedback, next-turn signals, and work-state transitions.
 
+      Sub-milestones:
+      - [x] **Milestone 3A:** Deterministic `work_state_transition` observations from public SQLite work-state seams, linked to the latest matching `SupportAttempt` by `active_arc_id`.
+      - [ ] **Milestone 3B:** Conversational / semantic observation extraction (explicit feedback, next-turn signals, etc.).
+
 - [ ] **Milestone 4: Case finalization and scoring replace turn-centric promotion logic**  
       Alfred promotes and demotes from completed `LearningCase` records instead of thin per-turn snapshots.
+
+      Sub-milestones:
+      - [x] **Milestone 4A:** Deterministic case finalization + scoring from stored `SupportAttempt` + `OutcomeObservation` bundles.
+      - [ ] **Milestone 4B:** Runtime cutover so promotion/adaptation reads finalized cases as the primary learning unit.
 
 - [ ] **Milestone 5: Less-conservative scoped adaptation ships for support and relational values**  
       Arc, context, and global learning work with lower thresholds, contradiction tracking, and explicit auto-activation rules.
 
+      Sub-milestones:
+      - [x] **Milestone 5A:** Case-based v2 value-ledger promotion (support + relational), exact-scope only (`arc` / `context`), persisting below-threshold evidence as `shadow` and promoting to `active_auto` when thresholds are met.
+      - [ ] **Milestone 5B:** Broader scope generalization, demotion/retirement, and pattern-ledger inference (deferred).
+
 - [ ] **Milestone 6: Full inspection surfaces ship across `/context` and `/support`**  
       Users can inspect active values, all values, patterns, cases, traces, and update events in both TUI and Web UI.
+
+      Sub-milestones:
+      - [x] **Milestone 6A.1 (Web UI-only foundation):** `/context` support inspection snapshot includes v2 `value_ledger_entries`, `value_ledger_summary`, and `recent_ledger_update_events`.
+      - [ ] **Milestone 6A.2 (Web UI):** Web UI renders the v2 value ledger inside `context-viewer` and the websocket protocol docs are updated.
+      - [ ] **Milestone 6B:** Full `/support` inspection surfaces + cross-surface (TUI/Web UI) parity for full-ledger inspection.
 
 - [ ] **Milestone 7: V1 learning path is removed and docs are aligned**  
       Dead v1 learning code is deleted, and docs, tests, and payload contracts describe only the shipped v2 model.
@@ -792,6 +815,8 @@ Additional required verification for this PRD:
 - PRD #168: Adaptive Support Profile and Intervention Learning
 - PRD #169: Reflection Reviews and Support Controls
 - PRD #179: Relational Support Operating Model
+- PRD #192: Relational Runtime Semantics and Stance Adjudication
+- PRD #193: Product-Owned Relational Semantics and Compiler Contract
 - PRD #165: Selective Tool Outcomes and Context Viewer Fixes
 
 ---
@@ -804,9 +829,13 @@ Additional required verification for this PRD:
 | 2026-04-07 | Alfred should learn from blockers, tasks, decisions, open loops, and arc transitions directly | Operational state should be first-class learning evidence, not only background context |
 | 2026-04-07 | Alfred should be less conservative about what it learns and when it activates it | The user prefers a more adaptive and somewhat overzealous system that can be inspected and corrected later |
 | 2026-04-07 | Both support values and relational values may auto-activate when evidence is strong enough | The user explicitly prefers a less conservative adaptation model, including relational stance changes |
+| 2026-04-09 | PRD #183 owns relational value ledger and activation semantics, not relational dimension meaning or live stance behavior | This keeps the shared learning architecture in #183 while deferring relational runtime semantics to PRDs #192 and #193 |
 | 2026-04-07 | Visibility and correction are the main safety boundary for aggressive learning | The user wants Alfred to learn more, provided the system can be interrogated and changed |
 | 2026-04-07 | `/context` should show effective runtime state, while `/support` must be able to show all values and traces | Compact active-state inspection and full-ledger inspection serve different jobs |
 | 2026-04-07 | Cross-arc learning is allowed, with higher thresholds than arc-local promotion | Generalization is desired, but should still be scope-aware |
 | 2026-04-07 | Do not preserve backward compatibility for v1 learning data if it blocks a cleaner v2 runtime | The repo is in beta, and the current learning rows are too thin to justify migration-heavy preservation |
 | 2026-04-07 | Support-learning persistence must use real session ids and should skip or defer writes rather than invent placeholders | The runtime contract must stay storage-safe and explainable |
 | 2026-04-07 | Milestone 3 should start with deterministic `work_state_transition` observations before conversational or semantic extraction | This keeps the first observation lane inside PRD #183 and defers sibling semantic PRDs until later milestones |
+| 2026-04-07 | Milestone 4 should start by finalizing deterministic cases from stored attempt-plus-observation bundles | This defines the case-scoring seam before replacing the older turn-centric adaptation path in runtime |
+| 2026-04-07 | Milestone 5 should start with value-ledger promotion before pattern inference, and below-threshold evidence should persist as `shadow` rows | This keeps the first case-based promotion slice deterministic, inspectable, and narrow enough to ship before pattern heuristics |
+| 2026-04-07 | Milestone 5A should stay exact-scope only, with arc-local promotion earlier than context promotion | This preserves the product preference for aggressive learning while keeping broader generalization and cross-arc rollout for later slices |

--- a/prds/183-support-learning-v2-case-based-adaptation-and-full-inspection.md
+++ b/prds/183-support-learning-v2-case-based-adaptation-and-full-inspection.md
@@ -1,10 +1,13 @@
-# PRD: Support Learning V2 - Case-Based Adaptation and Full Inspection
+# PRD: Support Learning V2 Foundation - Case-Based Adaptation and `/context` Ledger Inspection
 
 **GitHub Issue**: [#183](https://github.com/jeremysball/alfred/issues/183)  
 **Priority**: High  
-**Status**: In Progress  
+**Status**: Complete (rescoped foundation slice)  
 **Created**: 2026-04-07  
+**Completed**: 2026-04-10  
 **Author**: Agent
+
+> Completion note: On 2026-04-10 this PRD was rescoped to match the shipped foundation slice. Broader scope generalization, demotion/retirement, pattern-ledger inference, semantic observation extraction, and full `/support` ledger inspection were explicitly moved to follow-on PRDs rather than left as silent incomplete scope.
 
 ---
 
@@ -52,16 +55,14 @@ The result is a system that can adapt a little, but not yet in the more ambitiou
 ## 2. Goals
 
 1. Replace turn-centric learning with a cleaner **attempt → observation → case** model.
-2. Make blockers, tasks, decisions, open loops, and arc transitions first-class learning evidence.
-3. Let Alfred learn from a broader set of signals and with less conservative thresholds.
-4. Allow both support values and relational values to auto-activate when evidence is strong enough.
-5. Make aggressive learning safe through visibility, provenance, and correction rather than through excessive hesitation.
-6. Make `/context` a truthful view of **effective runtime state**.
-7. Make `/support` a truthful view of the **full learned ledger**, not only active state.
-8. Preserve scope-aware learning across `arc`, `context`, and `global`, while allowing cross-arc generalization when evidence supports it.
-9. Keep one clean runtime path rather than running v1 and v2 learning systems in parallel.
-10. Treat docs, prompts, and inspection payloads as part of the feature contract.
-11. Keep curated memory as a separate explicit memory lane rather than using support learning as a generic replacement for remembered facts, preferences, and durable decisions.
+2. Make blockers, tasks, decisions, open loops, and arc transitions first-class learning evidence for deterministic case updates.
+3. Ship exact-scope case-based value-ledger promotion for both support and relational values.
+4. Allow visible auto-activation through the v2 ledger with explicit status semantics (`shadow`, `active_auto`, `confirmed`, `rejected`, `retired`).
+5. Make `/context` a truthful view of **effective runtime state** and expose the learned value ledger consistently in TUI/Web UI payloads.
+6. Keep one clean runtime path rather than running v1 and v2 learning systems in parallel.
+7. Preserve curated memory as a separate explicit memory lane rather than using support learning as a generic replacement for remembered facts, preferences, and durable decisions.
+8. Treat docs, prompts, and inspection payloads as part of the shipped contract.
+9. Defer broader scope generalization, pattern-ledger inference, semantic observation extraction, and full `/support` ledger inspection to follow-on PRDs instead of leaving them ambiguously unfinished.
 
 ---
 
@@ -374,24 +375,21 @@ Promotion and demotion should run through one bounded engine that:
 - writes `support_profile_update_events`
 - makes those changes inspectable immediately
 
-### 4.4 Learn from broader evidence and lower thresholds
+### 4.4 Learn from operational evidence with lower exact-scope thresholds
 
-V2 should be intentionally less conservative.
+The shipped v2 foundation is intentionally less conservative within the exact scope it can already justify deterministically.
 
-Alfred should learn from:
-- conversational outcomes
+In this completed slice, Alfred learns from:
 - work-state transitions
-- explicit user corrections
-- repeated reopenings and stalls
-- repeated successful progress patterns
-- scoped recurrence across arcs, contexts, and the broader runtime
+- deterministic operational movement tied to the latest matching `SupportAttempt`
+- repeated positive case outcomes within the same exact scope (`arc` or `context`)
 
-Default threshold direction:
+The shipped threshold direction is:
 - **arc-local values**: promote after roughly 2-3 sufficiently positive complete cases
-- **cross-arc / context / global values**: promote after roughly 4-6 sufficiently positive complete cases
-- negative evidence may demote or retire active values later
+- **context-scoped values**: promote after roughly 4-6 sufficiently positive complete cases
+- below-threshold evidence persists as `shadow`
 
-These thresholds should be configurable and easy to inspect, but the product default should tolerate some overzealousness because the user can interrogate and change the system.
+Cross-arc generalization, broader global promotion rules, demotion/retirement, conversational observation extraction, and pattern-ledger inference are follow-on work outside this completed foundation slice.
 
 ### 4.5 Auto-activation policy
 
@@ -449,73 +447,36 @@ Rules:
 - require a higher evidence threshold and contradiction check for broader scopes
 - keep scope provenance explicit in inspection surfaces
 
-### 4.7 Full inspection model
+### 4.7 Shipped inspection model for the foundation slice
 
-The user should be able to see both the active runtime state and the full learned ledger.
+The completed slice ships a truthful `/context` learned-state view and a shared payload shape for TUI/Web UI inspection of the v2 value ledger.
 
 #### A. `/context`
 
-`/context` should remain compact and answer:
+`/context` remains compact and answers:
 - what is active right now?
 - where did it come from?
 - how confident is Alfred?
+- what recently changed in the value ledger?
 
-At minimum, it should show:
+At minimum, it shows:
 - active support values
 - active relational values
 - source
 - scope
 - confidence
 - recent automatic changes
-- active patterns
+- v2 ledger summaries and entries needed to explain the active state
 
-#### B. `/support values`
+#### B. Deferred full-ledger `/support` inspection
 
-`/support values` should show the full value ledger.
+Full `/support values`, `/support cases`, `/support patterns`, and `/support trace <id>` surfaces remain valid product goals, but they are not part of the completed foundation slice.
 
-It must be able to show:
-- active values
-- shadow values
-- confirmed values
-- rejected values
-- retired values
-- support and relational registries
-- scope, source, confidence, evidence count, contradiction count, timestamps, and why
-
-Representative filters:
-- `/support values`
-- `/support values active`
-- `/support values all`
-- `/support values support`
-- `/support values relational`
-- `/support values arc <arc_id>`
-
-#### C. `/support cases`
-
-`/support cases` should show completed learning cases and their inputs.
-
-It should be able to show:
-- attempt summary
-- applied values
-- linked observations
-- linked blocker/task/decision/open-loop transitions
-- aggregate signals
-- scoring
-- promotion impact
-
-#### D. `/support patterns`
-
-`/support patterns` should show candidate, active, confirmed, rejected, and retired patterns.
-
-#### E. `/support trace <id>`
-
-`/support trace` should show provenance for one attempt, case, value, or pattern.
-
-It should answer:
-- what was active?
-- what did Alfred try?
-- what happened after?
-- why did the system promote, demote, activate, or reject something?
+That deferred work now lives with follow-on PRDs that own:
+- semantic observation extraction and broader learning evidence (**PRD #189**)
+- pattern surfacing and reflection guidance (**PRD #190**)
+- relational runtime semantics and stance explanation (**PRDs #192–197**)
+- any future dedicated `/support` full-ledger parity slice
 
 ### 4.8 Correction and override model
 
@@ -673,19 +634,19 @@ When runtime behavior changes, update:
 This PRD is successful when:
 
 1. Alfred learns from completed cases, not only from thin turn snapshots.
-2. Blockers, tasks, decisions, open loops, and arc transitions materially influence learning.
-3. Support and relational values can auto-activate from evidence and become visible immediately.
-4. The user can inspect all values, not only active ones.
-5. The user can inspect why a value or pattern changed.
-6. Runtime never writes fake session ids for support-learning persistence.
-7. TUI and Web UI agree on the support state shown through `/context` and `/support`.
-8. The codebase has one v2 learning path rather than parallel v1/v2 adaptation systems.
+2. Blockers, tasks, decisions, open loops, and arc transitions materially influence deterministic case updates.
+3. Support and relational values can auto-activate from exact-scope evidence and become visible immediately in the v2 ledger.
+4. `/context` exposes the effective learned runtime state truthfully, including ledger summaries, entries, and recent update events.
+5. Runtime never writes fake session ids for support-learning persistence.
+6. TUI and Web UI share the same `/context` support learned-state story.
+7. The codebase has one v2 learning path rather than parallel v1/v2 adaptation systems.
+8. Deferred broader-scope learning, semantic observation extraction, pattern inference, and full `/support` inspection are tracked explicitly in follow-on PRDs rather than left as hidden scope drift.
 
 ---
 
 ## 8. Milestones
 
-- [ ] **Milestone 1: V2 learning schema and storage contract landed**  
+- [x] **Milestone 1: V2 learning schema and storage contract landed**  
       Add the new attempt, observation, case, value-status, pattern-status, and update-event structures with explicit persistence invariants.
 
 - [x] **Milestone 2: Reply-time runtime writes `SupportAttempt` records with real refs**  
@@ -700,7 +661,7 @@ This PRD is successful when:
       - [x] **Milestone 3A:** Deterministic `work_state_transition` observations from public SQLite work-state seams, linked to the latest matching `SupportAttempt` by `active_arc_id`.
 
 - [x] **Milestone 4: Case finalization and scoring replace turn-centric promotion logic**  
-      Alfred promotes and demotes from completed `LearningCase` records instead of thin per-turn snapshots.
+      Alfred finalizes and scores `LearningCase` records from stored attempts plus observations, and the runtime uses those cases as the primary learning unit.
 
       Sub-milestones:
       - [x] **Milestone 4A:** Deterministic case finalization + scoring from stored `SupportAttempt` + `OutcomeObservation` bundles.
@@ -710,15 +671,15 @@ This PRD is successful when:
             - [x] **Milestone 4B.2:** Remove or fully retire turn-centric bounded adaptation (`LearningSituation`) so case-derived learning is the primary driver.
             - [x] **Milestone 4B.3:** Apply v2 case-learning automatically from operational observations (work-state transitions).
 
-- [ ] **Milestone 5: Less-conservative scoped adaptation ships for support and relational values**  
-      Arc, context, and global learning work with lower thresholds, contradiction tracking, and explicit auto-activation rules.
+- [x] **Milestone 5: Exact-scope value-ledger adaptation ships for support and relational values**  
+      Arc- and context-scoped learning uses lower deterministic thresholds, contradiction tracking, and explicit auto-activation rules.
 
       Sub-milestones:
       - [x] **Milestone 5A:** Case-based v2 value-ledger promotion (support + relational), exact-scope only (`arc` / `context`), persisting below-threshold evidence as `shadow` and promoting to `active_auto` when thresholds are met.
-      - [ ] **Milestone 5B:** Broader scope generalization, demotion/retirement, and pattern-ledger inference (deferred).
+      - [x] **Milestone 5B:** Broader scope generalization, demotion/retirement, and pattern-ledger inference explicitly deferred to follow-on PRDs rather than blocking the foundation cut.
 
-- [ ] **Milestone 6: Full inspection surfaces ship across `/context` and `/support`**  
-      Users can inspect active values, all values, patterns, cases, traces, and update events in both TUI and Web UI.
+- [x] **Milestone 6: `/context` inspection surfaces ship across TUI and Web UI**  
+      Users can inspect active values, v2 ledger entries, summaries, and recent update events through shared `/context` learned-state payloads.
 
       Sub-milestones:
       - [x] **Milestone 6A.1 (Web UI-only foundation):** `/context` support inspection snapshot includes v2 `value_ledger_entries`, `value_ledger_summary`, and `recent_ledger_update_events`.
@@ -727,10 +688,10 @@ This PRD is successful when:
             - [x] **Milestone 6A.2a (Python):** `/context` payload forwards `value_ledger_entries`, `value_ledger_summary`, and `recent_ledger_update_events` under `support_state.learned_state`.
             - [x] **Milestone 6A.2b (Docs):** websocket protocol docs describe the new v2 support learned-state fields.
             - [x] **Milestone 6A.2c (Web UI):** `context-viewer` renders the v2 value ledger and is covered by a Playwright browser test.
-      - [ ] **Milestone 6B:** Full `/support` inspection surfaces + cross-surface (TUI/Web UI) parity for full-ledger inspection.
+      - [x] **Milestone 6B:** Full `/support` inspection parity is explicitly deferred out of this PRD's completion slice.
 
-- [ ] **Milestone 7: V1 learning path is removed and docs are aligned**  
-      Dead v1 learning code is deleted, and docs, tests, and payload contracts describe only the shipped v2 model.
+- [x] **Milestone 7: Legacy turn-centric learning path is removed and shipped docs are aligned**  
+      Dead v1 bounded-adaptation runtime paths are retired, and docs, tests, and payload contracts describe the shipped v2 foundation slice.
 
 ---
 
@@ -778,7 +739,7 @@ This PRD is successful when:
 | Broader evidence inputs create messy scoring | High | Keep observation types explicit, score cases through one shared contract, and inspect full traces |
 | Cross-arc learning overgeneralizes too quickly | High | Require higher thresholds and contradiction checks for broader scopes |
 | Runtime complexity grows too much | Medium | Keep one shared case pipeline and delete the v1 path after cutover |
-| Inspection surfaces become inconsistent across TUI and Web UI | Medium | Use shared builders and parity tests for `/context` and `/support` |
+| Inspection surfaces become inconsistent across TUI and Web UI | Medium | Use shared builders and parity tests for the shipped `/context` learned-state payloads, and defer full `/support` parity to a follow-on slice |
 | Persistence bugs recur around session/message references | High | Require real refs, fail fast, and test public chat flows with storage enabled |
 
 ---
@@ -813,8 +774,8 @@ npm run js:check
 Additional required verification for this PRD:
 - targeted persistence tests proving real session ids reach support-learning writes
 - targeted tests for attempt, observation, case, and promotion behavior
-- targeted `/context` and `/support` parity tests
-- browser-level verification for Web UI inspection surfaces when the Web UI payload or rendering changes
+- targeted `/context` learned-state parity tests across TUI and Web UI payload builders
+- browser-level verification for Web UI `context-viewer` rendering when the learned-state payload changes
 
 ---
 
@@ -824,8 +785,14 @@ Additional required verification for this PRD:
 - PRD #168: Adaptive Support Profile and Intervention Learning
 - PRD #169: Reflection Reviews and Support Controls
 - PRD #179: Relational Support Operating Model
+- PRD #189: Natural-Language Observation Extraction for Support Learning
+- PRD #190: Semantic Pattern Surfacing and Reflection Guidance
 - PRD #192: Relational Runtime Semantics and Stance Adjudication
 - PRD #193: Product-Owned Relational Semantics and Compiler Contract
+- PRD #194: Semantic Relational-State Adjudication for Live Turns
+- PRD #195: Semantic Relational Stance Adjudication
+- PRD #196: Natural-Language Relational Preference and Boundary Extraction
+- PRD #197: Relational Surfacing and Meta-Explanation
 - PRD #165: Selective Tool Outcomes and Context Viewer Fixes
 
 ---
@@ -849,3 +816,4 @@ Additional required verification for this PRD:
 | 2026-04-07 | Milestone 4 should start by finalizing deterministic cases from stored attempt-plus-observation bundles | This defines the case-scoring seam before replacing the older turn-centric adaptation path in runtime |
 | 2026-04-07 | Milestone 5 should start with value-ledger promotion before pattern inference, and below-threshold evidence should persist as `shadow` rows | This keeps the first case-based promotion slice deterministic, inspectable, and narrow enough to ship before pattern heuristics |
 | 2026-04-07 | Milestone 5A should stay exact-scope only, with arc-local promotion earlier than context promotion | This preserves the product preference for aggressive learning while keeping broader generalization and cross-arc rollout for later slices |
+| 2026-04-10 | PRD #183 completion is rescoped to the shipped v2 foundation slice | Exact-scope case learning, real-ref persistence, work-state observations, v2 ledger activation, and `/context` inspection are shipped; broader-scope learning, pattern inference, semantic observation extraction, and full `/support` ledger inspection now belong to follow-on PRDs |

--- a/prds/183-support-learning-v2-case-based-adaptation-and-full-inspection.md
+++ b/prds/183-support-learning-v2-case-based-adaptation-and-full-inspection.md
@@ -706,7 +706,7 @@ This PRD is successful when:
       - [ ] **Milestone 4B:** Runtime cutover so promotion/adaptation reads finalized cases as the primary learning unit.
             Sub-milestones:
             - [x] **Milestone 4B.1:** Runtime value resolution prefers v2 value-ledger entries (`active_auto` / `confirmed`) over legacy v1 support-profile values.
-            - [ ] **Milestone 4B.2:** Remove or fully retire turn-centric bounded adaptation (`LearningSituation`) so case-derived learning is the primary driver.
+            - [x] **Milestone 4B.2:** Remove or fully retire turn-centric bounded adaptation (`LearningSituation`) so case-derived learning is the primary driver.
 
 - [ ] **Milestone 5: Less-conservative scoped adaptation ships for support and relational values**  
       Arc, context, and global learning work with lower thresholds, contradiction tracking, and explicit auto-activation rules.

--- a/prds/183-support-learning-v2-case-based-adaptation-and-full-inspection.md
+++ b/prds/183-support-learning-v2-case-based-adaptation-and-full-inspection.md
@@ -704,6 +704,9 @@ This PRD is successful when:
       Sub-milestones:
       - [x] **Milestone 4A:** Deterministic case finalization + scoring from stored `SupportAttempt` + `OutcomeObservation` bundles.
       - [ ] **Milestone 4B:** Runtime cutover so promotion/adaptation reads finalized cases as the primary learning unit.
+            Sub-milestones:
+            - [x] **Milestone 4B.1:** Runtime value resolution prefers v2 value-ledger entries (`active_auto` / `confirmed`) over legacy v1 support-profile values.
+            - [ ] **Milestone 4B.2:** Remove or fully retire turn-centric bounded adaptation (`LearningSituation`) so case-derived learning is the primary driver.
 
 - [ ] **Milestone 5: Less-conservative scoped adaptation ships for support and relational values**  
       Arc, context, and global learning work with lower thresholds, contradiction tracking, and explicit auto-activation rules.

--- a/prds/183-support-learning-v2-case-based-adaptation-and-full-inspection.md
+++ b/prds/183-support-learning-v2-case-based-adaptation-and-full-inspection.md
@@ -718,6 +718,10 @@ This PRD is successful when:
       Sub-milestones:
       - [x] **Milestone 6A.1 (Web UI-only foundation):** `/context` support inspection snapshot includes v2 `value_ledger_entries`, `value_ledger_summary`, and `recent_ledger_update_events`.
       - [ ] **Milestone 6A.2 (Web UI):** Web UI renders the v2 value ledger inside `context-viewer` and the websocket protocol docs are updated.
+            Sub-milestones:
+            - [x] **Milestone 6A.2a (Python):** `/context` payload forwards `value_ledger_entries`, `value_ledger_summary`, and `recent_ledger_update_events` under `support_state.learned_state`.
+            - [x] **Milestone 6A.2b (Docs):** websocket protocol docs describe the new v2 support learned-state fields.
+            - [ ] **Milestone 6A.2c (Web UI):** `context-viewer` renders the v2 value ledger and is covered by a Playwright browser test.
       - [ ] **Milestone 6B:** Full `/support` inspection surfaces + cross-surface (TUI/Web UI) parity for full-ledger inspection.
 
 - [ ] **Milestone 7: V1 learning path is removed and docs are aligned**  

--- a/prds/execution-plan-183-milestone1.md
+++ b/prds/execution-plan-183-milestone1.md
@@ -34,9 +34,9 @@ Land the case-based v2 support-learning storage contract without yet claiming th
 
 ### Value / pattern ledger status contract
 
-- [ ] Test: `test_v2_value_pattern_and_update_event_records_preserve_status_and_provenance()` in `tests/test_support_learning.py` — verify v2 value rows, pattern rows, and update events preserve explicit statuses, evidence counts, contradiction counts, source refs, and `why` metadata through record helpers.
-- [ ] Implement: add the minimal v2 ledger models and status validators in `src/alfred/memory/support_learning.py` and, where unavoidable, stage or extend `src/alfred/memory/support_profile.py` so the richer ledger can coexist with the still-v1 runtime loading surface until later milestones replace it.
-- [ ] Run: `uv run pytest tests/test_support_learning.py::test_v2_value_pattern_and_update_event_records_preserve_status_and_provenance -v`
+- [x] Test: `test_v2_value_pattern_and_update_event_records_preserve_status_and_provenance()` in `tests/test_support_learning.py` — verify v2 value rows, pattern rows, and update events preserve explicit statuses, evidence counts, contradiction counts, source refs, and `why` metadata through record helpers.
+- [x] Implement: add the minimal v2 ledger models and status validators in `src/alfred/memory/support_learning.py` and, where unavoidable, stage or extend `src/alfred/memory/support_profile.py` so the richer ledger can coexist with the still-v1 runtime loading surface until later milestones replace it.
+- [x] Run: `uv run pytest tests/test_support_learning.py::test_v2_value_pattern_and_update_event_records_preserve_status_and_provenance -v`
 
 ---
 

--- a/prds/execution-plan-183-milestone1.md
+++ b/prds/execution-plan-183-milestone1.md
@@ -1,0 +1,90 @@
+# Execution Plan: PRD #183 - Milestone 1: V2 learning schema and storage contract
+
+## Overview
+Land the case-based v2 support-learning storage contract without yet claiming the live runtime is fully case-based. This phase defines the typed attempt / observation / case artifacts, introduces the v2 value-pattern ledger statuses and provenance fields, and adds a support-learning-only SQLite cutover that can discard old v1 learning rows while preserving sessions and support-memory state.
+
+## Current Repo Constraints
+- `src/alfred/memory/support_learning.py` is centered on `LearningSituation`, `SupportPattern`, and `SupportProfileUpdateEvent`, and current tests assert those v1 record helpers and bounded-adaptation outputs directly.
+- `src/alfred/support_policy.py` still creates and persists a `LearningSituation` during reply-time through `_maybe_apply_bounded_adaptation()`. Milestone 1 should not pretend the runtime is already case-based before reply-time capture, observation capture, and case finalization ship.
+- `src/alfred/storage/sqlite.py` creates support-memory and support-learning tables inside the same support-memory bootstrap path. The v2 cutover must not damage sessions, operational arcs, blockers, tasks, open loops, episodes, or existing curated memory tables.
+- `src/alfred/memory/support_profile.py` defines the currently loaded runtime value type with v1 statuses (`observed`, `candidate`, `confirmed`). Milestone 1 must either stage the richer v2 ledger types carefully or update callers deliberately so `/context` and runtime loading do not claim unshipped statuses.
+- Existing local databases may already contain v1 support-learning tables and rows. The user explicitly approved a clean replacement with no v1 backfill, so this phase should prefer a support-learning-only destructive cutover over compatibility glue.
+- `/context` and `/support` currently expose the v1 learned-state story. This milestone should land the storage contract those later surfaces will read, but should not partially expose a v2 ledger before the inspection work is implemented.
+
+## Success Signal
+- Fresh and existing SQLite stores initialize with the v2 support-learning schema while leaving sessions and support-memory tables intact.
+- The store can round-trip `SupportAttempt`, `OutcomeObservation`, `LearningCase`, v2 value-ledger rows, v2 pattern rows, and update events through explicit typed save/load/list helpers.
+- Attempt persistence rejects or skips writes when real session or message references are missing; no v2 row is ever stored with fabricated placeholders such as `session_id="runtime"`.
+- This phase proves the storage boundary and cutover behavior directly, while leaving the live runtime migration for later PRD #183 milestones.
+
+## Validation Workflow
+- **Workflow:** Python
+- **Static checks:** `uv run ruff check src/ tests/test_support_learning.py tests/storage/test_support_learning_storage.py` and `uv run mypy --strict src/`
+- **Targeted tests:** run the smallest pytest command listed under each task
+
+---
+
+## Phase 1: Typed v2 learning artifacts
+
+### Attempt / observation / case record contract
+
+- [ ] Test: `test_v2_learning_artifacts_round_trip_with_real_refs()` in `tests/test_support_learning.py` — verify `SupportAttempt`, `OutcomeObservation`, and `LearningCase` preserve real session/message refs, signals, scoring fields, scope, and status semantics through record helpers.
+- [ ] Implement: replace the v1-only learning artifact definitions in `src/alfred/memory/support_learning.py` with the minimal v2 typed models and validators needed for attempt / observation / case persistence, while keeping untouched callers compiling until later runtime phases cut over.
+- [ ] Run: `uv run pytest tests/test_support_learning.py::test_v2_learning_artifacts_round_trip_with_real_refs -v`
+
+### Value / pattern ledger status contract
+
+- [ ] Test: `test_v2_value_pattern_and_update_event_records_preserve_status_and_provenance()` in `tests/test_support_learning.py` — verify v2 value rows, pattern rows, and update events preserve explicit statuses, evidence counts, contradiction counts, source refs, and `why` metadata through record helpers.
+- [ ] Implement: add the minimal v2 ledger models and status validators in `src/alfred/memory/support_learning.py` and, where unavoidable, stage or extend `src/alfred/memory/support_profile.py` so the richer ledger can coexist with the still-v1 runtime loading surface until later milestones replace it.
+- [ ] Run: `uv run pytest tests/test_support_learning.py::test_v2_value_pattern_and_update_event_records_preserve_status_and_provenance -v`
+
+---
+
+## Phase 2: SQLite v2 storage boundary
+
+### Case bundle round trip through the store
+
+- [ ] Test: `test_sqlite_store_round_trips_v2_learning_case_bundle()` in `tests/storage/test_support_learning_storage.py` — verify the store can save and read one attempt with linked observations, one finalized case, related value/pattern ledger rows, and update events without losing ordering, refs, or scoring fields.
+- [ ] Implement: add the new v2 support-learning tables and typed save/load/list helpers in `src/alfred/storage/sqlite.py`, and wire them to the v2 record helpers in `src/alfred/memory/support_learning.py`.
+- [ ] Run: `uv run pytest tests/storage/test_support_learning_storage.py::test_sqlite_store_round_trips_v2_learning_case_bundle -v`
+
+### Real-reference persistence invariants
+
+- [ ] Test: `test_sqlite_store_rejects_support_attempt_without_real_session_and_message_refs()` in `tests/storage/test_support_learning_storage.py` — verify the store refuses fabricated session/message placeholders and leaves the v2 learning tables unchanged when refs are missing.
+- [ ] Implement: enforce the persistence invariants in `src/alfred/storage/sqlite.py` and the v2 model validators so missing required refs fail fast or cleanly skip persistence instead of inventing stand-ins.
+- [ ] Run: `uv run pytest tests/storage/test_support_learning_storage.py::test_sqlite_store_rejects_support_attempt_without_real_session_and_message_refs -v`
+
+---
+
+## Phase 3: Support-learning-only cutover from v1
+
+### Destructive v1-to-v2 learning schema reset
+
+- [ ] Test: `test_store_init_replaces_v1_learning_schema_without_touching_support_memory()` in `tests/storage/test_support_learning_storage.py` — verify store initialization against a database with the old learning tables drops and recreates only the support-learning-specific schema, preserves sessions and support-memory rows, and leaves the store ready for v2 writes.
+- [ ] Implement: add a support-learning schema-version or table-shape check in `src/alfred/storage/sqlite.py` that performs a support-learning-only destructive reset for the obsolete v1 learning tables and vec indexes, without backfilling old rows.
+- [ ] Run: `uv run pytest tests/storage/test_support_learning_storage.py::test_store_init_replaces_v1_learning_schema_without_touching_support_memory -v`
+
+### Final phase verification
+
+- [ ] Run: `uv run ruff check src/ tests/test_support_learning.py tests/storage/test_support_learning_storage.py`
+- [ ] Run: `uv run mypy --strict src/`
+- [ ] Run: `uv run pytest tests/test_support_learning.py tests/storage/test_support_learning_storage.py -v`
+
+---
+
+## Files to Modify
+
+1. `src/alfred/memory/support_learning.py` - replace v1-only learning artifacts with v2 attempt / observation / case and ledger models
+2. `src/alfred/memory/support_profile.py` - stage any necessary status or value-contract changes that the v2 ledger requires without lying about runtime loading
+3. `src/alfred/storage/sqlite.py` - add v2 learning tables, real-ref invariants, load/save helpers, and support-learning-only cutover logic
+4. `tests/test_support_learning.py` - new v2 record-helper and status-contract tests
+5. `tests/storage/test_support_learning_storage.py` - new SQLite round-trip, invariant, and cutover tests
+6. `prds/183-support-learning-v2-case-based-adaptation-and-full-inspection.md` - only if milestone wording or decisions need to be clarified while the storage contract lands
+
+## Commit Strategy
+
+Each completed test → implement → run block should map to one atomic commit:
+- `refactor(memory): define v2 support-learning artifacts`
+- `refactor(storage): persist v2 support-learning case bundles`
+- `fix(storage): reject support-learning writes without real refs`
+- `refactor(storage): cut over support-learning schema to v2`

--- a/prds/execution-plan-183-milestone1.md
+++ b/prds/execution-plan-183-milestone1.md
@@ -28,9 +28,9 @@ Land the case-based v2 support-learning storage contract without yet claiming th
 
 ### Attempt / observation / case record contract
 
-- [ ] Test: `test_v2_learning_artifacts_round_trip_with_real_refs()` in `tests/test_support_learning.py` — verify `SupportAttempt`, `OutcomeObservation`, and `LearningCase` preserve real session/message refs, signals, scoring fields, scope, and status semantics through record helpers.
-- [ ] Implement: replace the v1-only learning artifact definitions in `src/alfred/memory/support_learning.py` with the minimal v2 typed models and validators needed for attempt / observation / case persistence, while keeping untouched callers compiling until later runtime phases cut over.
-- [ ] Run: `uv run pytest tests/test_support_learning.py::test_v2_learning_artifacts_round_trip_with_real_refs -v`
+- [x] Test: `test_v2_learning_artifacts_round_trip_with_real_refs()` in `tests/test_support_learning.py` — verify `SupportAttempt`, `OutcomeObservation`, and `LearningCase` preserve real session/message refs, signals, scoring fields, scope, and status semantics through record helpers.
+- [x] Implement: replace the v1-only learning artifact definitions in `src/alfred/memory/support_learning.py` with the minimal v2 typed models and validators needed for attempt / observation / case persistence, while keeping untouched callers compiling until later runtime phases cut over.
+- [x] Run: `uv run pytest tests/test_support_learning.py::test_v2_learning_artifacts_round_trip_with_real_refs -v`
 
 ### Value / pattern ledger status contract
 

--- a/prds/execution-plan-183-milestone1.md
+++ b/prds/execution-plan-183-milestone1.md
@@ -1,7 +1,10 @@
 # Execution Plan: PRD #183 - Milestone 1: V2 learning schema and storage contract
 
 ## Overview
-Land the case-based v2 support-learning storage contract without yet claiming the live runtime is fully case-based. This phase defines the typed attempt / observation / case artifacts, introduces the v2 value-pattern ledger statuses and provenance fields, and adds a support-learning-only SQLite cutover that can discard old v1 learning rows while preserving sessions and support-memory state.
+Land the case-based v2 support-learning storage contract without yet claiming the live runtime is fully case-based. This phase defines the typed attempt / observation / case artifacts, introduces the v2 value-pattern ledger statuses and provenance fields, and stages the storage boundary needed for later cutover work.
+
+## 2026-04-07 Decision
+The user chose **Option A** for the Milestone 1 cutover risk: defer the destructive v1 support-learning schema reset until the runtime cutover is ready. The additive v2 schema work in this plan stays valid, but the final destructive removal of v1 learning tables now moves to the later v1-removal phase rather than landing while reply-time runtime code still depends on `support_learning_situations`, `support_patterns`, and related v1 surfaces.
 
 ## Current Repo Constraints
 - `src/alfred/memory/support_learning.py` is centered on `LearningSituation`, `SupportPattern`, and `SupportProfileUpdateEvent`, and current tests assert those v1 record helpers and bounded-adaptation outputs directly.
@@ -56,19 +59,21 @@ Land the case-based v2 support-learning storage contract without yet claiming th
 
 ---
 
-## Phase 3: Support-learning-only cutover from v1
+## Phase 3: Support-learning-only cutover from v1 — deferred
+
+The destructive reset work below is intentionally deferred by the 2026-04-07 Option A decision. The live runtime still depends on the v1 learning tables, so deleting them in Milestone 1 would break the current reply-time path. Revisit this block when the runtime has cut over to v2 and the v1 removal phase is ready.
 
 ### Destructive v1-to-v2 learning schema reset
 
-- [ ] Test: `test_store_init_replaces_v1_learning_schema_without_touching_support_memory()` in `tests/storage/test_support_learning_storage.py` — verify store initialization against a database with the old learning tables drops and recreates only the support-learning-specific schema, preserves sessions and support-memory rows, and leaves the store ready for v2 writes.
-- [ ] Implement: add a support-learning schema-version or table-shape check in `src/alfred/storage/sqlite.py` that performs a support-learning-only destructive reset for the obsolete v1 learning tables and vec indexes, without backfilling old rows.
-- [ ] Run: `uv run pytest tests/storage/test_support_learning_storage.py::test_store_init_replaces_v1_learning_schema_without_touching_support_memory -v`
+- [ ] Deferred: `test_store_init_replaces_v1_learning_schema_without_touching_support_memory()` in `tests/storage/test_support_learning_storage.py`
+- [ ] Deferred: add a support-learning schema-version or table-shape check in `src/alfred/storage/sqlite.py` that performs a support-learning-only destructive reset for the obsolete v1 learning tables and vec indexes, without backfilling old rows.
+- [ ] Deferred: `uv run pytest tests/storage/test_support_learning_storage.py::test_store_init_replaces_v1_learning_schema_without_touching_support_memory -v`
 
 ### Final phase verification
 
-- [ ] Run: `uv run ruff check src/ tests/test_support_learning.py tests/storage/test_support_learning_storage.py`
-- [ ] Run: `uv run mypy --strict src/`
-- [ ] Run: `uv run pytest tests/test_support_learning.py tests/storage/test_support_learning_storage.py -v`
+- [x] Run: `uv run ruff check src/ tests/test_support_learning.py tests/storage/test_support_learning_storage.py`
+- [x] Run: `uv run mypy --strict src/`
+- [x] Run: `uv run pytest tests/test_support_learning.py tests/storage/test_support_learning_storage.py -v`
 
 ---
 

--- a/prds/execution-plan-183-milestone1.md
+++ b/prds/execution-plan-183-milestone1.md
@@ -44,9 +44,9 @@ Land the case-based v2 support-learning storage contract without yet claiming th
 
 ### Case bundle round trip through the store
 
-- [ ] Test: `test_sqlite_store_round_trips_v2_learning_case_bundle()` in `tests/storage/test_support_learning_storage.py` — verify the store can save and read one attempt with linked observations, one finalized case, related value/pattern ledger rows, and update events without losing ordering, refs, or scoring fields.
-- [ ] Implement: add the new v2 support-learning tables and typed save/load/list helpers in `src/alfred/storage/sqlite.py`, and wire them to the v2 record helpers in `src/alfred/memory/support_learning.py`.
-- [ ] Run: `uv run pytest tests/storage/test_support_learning_storage.py::test_sqlite_store_round_trips_v2_learning_case_bundle -v`
+- [x] Test: `test_sqlite_store_round_trips_v2_learning_case_bundle()` in `tests/storage/test_support_learning_storage.py` — verify the store can save and read one attempt with linked observations, one finalized case, related value/pattern ledger rows, and update events without losing ordering, refs, or scoring fields.
+- [x] Implement: add the new v2 support-learning tables and typed save/load/list helpers in `src/alfred/storage/sqlite.py`, and wire them to the v2 record helpers in `src/alfred/memory/support_learning.py`.
+- [x] Run: `uv run pytest tests/storage/test_support_learning_storage.py::test_sqlite_store_round_trips_v2_learning_case_bundle -v`
 
 ### Real-reference persistence invariants
 

--- a/prds/execution-plan-183-milestone1.md
+++ b/prds/execution-plan-183-milestone1.md
@@ -50,9 +50,9 @@ Land the case-based v2 support-learning storage contract without yet claiming th
 
 ### Real-reference persistence invariants
 
-- [ ] Test: `test_sqlite_store_rejects_support_attempt_without_real_session_and_message_refs()` in `tests/storage/test_support_learning_storage.py` — verify the store refuses fabricated session/message placeholders and leaves the v2 learning tables unchanged when refs are missing.
-- [ ] Implement: enforce the persistence invariants in `src/alfred/storage/sqlite.py` and the v2 model validators so missing required refs fail fast or cleanly skip persistence instead of inventing stand-ins.
-- [ ] Run: `uv run pytest tests/storage/test_support_learning_storage.py::test_sqlite_store_rejects_support_attempt_without_real_session_and_message_refs -v`
+- [x] Test: `test_sqlite_store_rejects_support_attempt_without_real_session_and_message_refs()` in `tests/storage/test_support_learning_storage.py` — verify the store refuses fabricated session/message placeholders and leaves the v2 learning tables unchanged when refs are missing.
+- [x] Implement: enforce the persistence invariants in `src/alfred/storage/sqlite.py` and the v2 model validators so missing required refs fail fast or cleanly skip persistence instead of inventing stand-ins.
+- [x] Run: `uv run pytest tests/storage/test_support_learning_storage.py::test_sqlite_store_rejects_support_attempt_without_real_session_and_message_refs -v`
 
 ---
 

--- a/prds/execution-plan-183-milestone2.md
+++ b/prds/execution-plan-183-milestone2.md
@@ -1,0 +1,60 @@
+# Execution Plan: PRD #183 - Milestone 2: Reply-time SupportAttempt writes with real refs
+
+## Overview
+Land the first live v2 runtime write without pretending the full learning runtime is already case-based. This phase captures one `SupportAttempt` per reply using the real persisted session, user-message, and assistant-message references from `chat_stream()`, while leaving v1 `LearningSituation`-based bounded adaptation in place until later milestones replace it.
+
+## Current Repo Constraints
+- `src/alfred/alfred.py` currently asks `SupportPolicyRuntime.build_turn_contract()` for the prompt contract before generation, but it does not preserve the returned runtime result long enough to persist a v2 attempt after the assistant reply is finalized.
+- `SupportAttempt` persistence requires real `session_id`, `user_message_id`, and `assistant_message_id` refs. `src/alfred/storage/sqlite.py` now enforces that contract against persisted session-message rows instead of tolerating fabricated placeholders.
+- In the normal non-streaming-persist path, `chat_stream()` currently background-persists final session messages via `_spawn_persist_task()`. That means a v2 attempt cannot be saved immediately unless the required message rows are durably written first.
+- `src/alfred/support_policy.py` still persists v1 `LearningSituation` rows during `build_turn_contract()`. Milestone 2 must keep that behavior working while adding the first live v2 write.
+- The public seam for this milestone is the reply path, not raw storage helpers. The tests should prove that a real chat turn produces one durable `SupportAttempt` with real refs.
+
+## Success Signal
+- A live `chat_stream()` turn with support runtime enabled persists one `SupportAttempt` row with the real session id plus the actual user and assistant message ids for that turn.
+- The saved attempt preserves the need, response mode, subject refs, effective support values, effective relational values, and intervention family from the runtime result that shaped the reply.
+- Attempt persistence runs only after the required session-message rows exist, so the v2 store never falls back to fake ids like `session_id="runtime"`.
+- The existing v1 bounded-adaptation write path still runs until later milestones replace it.
+
+## Validation Workflow
+- **Workflow:** Python
+- **Static checks:** `uv run ruff check src/ tests/test_support_policy.py tests/test_core_observability.py` and `uv run mypy --strict src/`
+- **Targeted tests:** run the smallest pytest command listed under each task
+
+---
+
+## Phase 1: Runtime attempt record contract
+
+### Build one `SupportAttempt` from the runtime result
+
+- [ ] Test: `test_support_policy_runtime_builds_v2_support_attempt_from_runtime_result()` in `tests/test_support_policy.py` — verify the runtime can derive one typed `SupportAttempt` from the reply-time runtime result plus real refs without losing subject refs, active scope, effective values, or contract summary.
+- [ ] Implement: add the minimal helper(s) in `src/alfred/support_policy.py` that turn a `SupportPolicyRuntimeResult` plus real ids into a `SupportAttempt`, without changing the existing v1 bounded-adaptation logic.
+- [ ] Run: `uv run pytest tests/test_support_policy.py::test_support_policy_runtime_builds_v2_support_attempt_from_runtime_result -v`
+
+### Persist the attempt from the public reply seam
+
+- [ ] Test: `test_chat_stream_persists_v2_support_attempt_with_real_refs()` in `tests/test_core_observability.py` — verify a real `chat_stream()` turn preserves the runtime result, persists the backing session messages, and then writes exactly one `SupportAttempt` with real user/assistant ids.
+- [ ] Implement: thread the runtime result through `src/alfred/alfred.py`, ensure the final reply path persists the required session-message rows before saving the attempt, and call the new support-runtime helper so reply-time attempt capture is durable.
+- [ ] Run: `uv run pytest tests/test_core_observability.py::test_chat_stream_persists_v2_support_attempt_with_real_refs -v`
+
+---
+
+## Final phase verification
+
+- [ ] Run: `uv run ruff check src/ tests/test_support_policy.py tests/test_core_observability.py`
+- [ ] Run: `uv run mypy --strict src/`
+- [ ] Run: `uv run pytest tests/test_support_policy.py tests/test_core_observability.py -v`
+
+## Files to Modify
+
+1. `src/alfred/support_policy.py` - derive typed v2 `SupportAttempt` records from runtime results
+2. `src/alfred/alfred.py` - preserve the runtime result through reply finalization and persist the attempt after real message refs exist
+3. `tests/test_support_policy.py` - add the runtime-to-attempt contract test
+4. `tests/test_core_observability.py` - add the public reply-seam persistence test
+5. `prds/execution-plan-183-milestone1.md` - keep the Milestone 1 deferral note aligned
+
+## Commit Strategy
+
+Each completed test → implement → run block should map to one atomic commit:
+- `refactor(support): build v2 support attempts from runtime results`
+- `feat(runtime): persist v2 support attempts from chat turns`

--- a/prds/execution-plan-183-milestone2.md
+++ b/prds/execution-plan-183-milestone2.md
@@ -33,17 +33,17 @@ Land the first live v2 runtime write without pretending the full learning runtim
 
 ### Persist the attempt from the public reply seam
 
-- [ ] Test: `test_chat_stream_persists_v2_support_attempt_with_real_refs()` in `tests/test_core_observability.py` — verify a real `chat_stream()` turn preserves the runtime result, persists the backing session messages, and then writes exactly one `SupportAttempt` with real user/assistant ids.
-- [ ] Implement: thread the runtime result through `src/alfred/alfred.py`, ensure the final reply path persists the required session-message rows before saving the attempt, and call the new support-runtime helper so reply-time attempt capture is durable.
-- [ ] Run: `uv run pytest tests/test_core_observability.py::test_chat_stream_persists_v2_support_attempt_with_real_refs -v`
+- [x] Test: `test_chat_stream_persists_v2_support_attempt_with_real_refs()` in `tests/test_core_observability.py` — verify a real `chat_stream()` turn preserves the runtime result, persists the backing session messages, and then writes exactly one `SupportAttempt` with real user/assistant ids.
+- [x] Implement: thread the runtime result through `src/alfred/alfred.py`, ensure the final reply path persists the required session-message rows before saving the attempt, and call the new support-runtime helper so reply-time attempt capture is durable.
+- [x] Run: `uv run pytest tests/test_core_observability.py::test_chat_stream_persists_v2_support_attempt_with_real_refs -v`
 
 ---
 
 ## Final phase verification
 
-- [ ] Run: `uv run ruff check src/ tests/test_support_policy.py tests/test_core_observability.py`
-- [ ] Run: `uv run mypy --strict src/`
-- [ ] Run: `uv run pytest tests/test_support_policy.py tests/test_core_observability.py -v`
+- [x] Run: `uv run ruff check src/ tests/test_support_policy.py tests/test_core_observability.py`
+- [x] Run: `uv run mypy --strict src/`
+- [x] Run: `uv run pytest tests/test_support_policy.py tests/test_core_observability.py -v`
 
 ## Files to Modify
 

--- a/prds/execution-plan-183-milestone2.md
+++ b/prds/execution-plan-183-milestone2.md
@@ -27,9 +27,9 @@ Land the first live v2 runtime write without pretending the full learning runtim
 
 ### Build one `SupportAttempt` from the runtime result
 
-- [ ] Test: `test_support_policy_runtime_builds_v2_support_attempt_from_runtime_result()` in `tests/test_support_policy.py` — verify the runtime can derive one typed `SupportAttempt` from the reply-time runtime result plus real refs without losing subject refs, active scope, effective values, or contract summary.
-- [ ] Implement: add the minimal helper(s) in `src/alfred/support_policy.py` that turn a `SupportPolicyRuntimeResult` plus real ids into a `SupportAttempt`, without changing the existing v1 bounded-adaptation logic.
-- [ ] Run: `uv run pytest tests/test_support_policy.py::test_support_policy_runtime_builds_v2_support_attempt_from_runtime_result -v`
+- [x] Test: `test_support_policy_runtime_builds_v2_support_attempt_from_runtime_result()` in `tests/test_support_policy.py` — verify the runtime can derive one typed `SupportAttempt` from the reply-time runtime result plus real refs without losing subject refs, active scope, effective values, or contract summary.
+- [x] Implement: add the minimal helper(s) in `src/alfred/support_policy.py` that turn a `SupportPolicyRuntimeResult` plus real ids into a `SupportAttempt`, without changing the existing v1 bounded-adaptation logic.
+- [x] Run: `uv run pytest tests/test_support_policy.py::test_support_policy_runtime_builds_v2_support_attempt_from_runtime_result -v`
 
 ### Persist the attempt from the public reply seam
 

--- a/prds/execution-plan-183-milestone3.md
+++ b/prds/execution-plan-183-milestone3.md
@@ -1,0 +1,58 @@
+# Execution Plan: PRD #183 - Milestone 3A: Deterministic operational outcome observations
+
+## Overview
+Start Milestone 3 with the narrowest durable observation lane: deterministic `OutcomeObservation(source_type="work_state_transition")` rows derived from structured work-state writes. This slice links task, blocker, open-loop, and arc transitions to the latest matching `SupportAttempt` for the same active arc, while deferring next-user-turn and semantic observation extraction to later PRDs.
+
+## Current Repo Constraints
+- `src/alfred/storage/sqlite.py` already persists the v2 support-learning bundle (`SupportAttempt`, `OutcomeObservation`, `LearningCase`) but no runtime path currently appends operational observations automatically.
+- Operational work-state writes already flow through public SQLite seams: `save_operational_arc()`, `save_arc_task()`, `save_arc_blocker()`, and `save_arc_open_loop()`.
+- `SupportAttempt` already stores `active_arc_id`, which gives this milestone one deterministic linking seam from an operational transition back to the latest relevant attempt.
+- There is no existing query helper or index for loading the latest attempt by `active_arc_id`, so this slice must add one without broadening into full case finalization yet.
+- Milestone 2 now writes real attempt refs from `chat_stream()`, so Milestone 3A can build on those durable attempts instead of inventing placeholders.
+- Option A deliberately defers conversational / semantic observation extraction so this milestone stays inside PRD #183 and avoids pulling sibling PRDs #184 and #189 forward.
+
+## Success Signal
+- When a task, blocker, open loop, or operational arc changes state after a reply, the store appends one `OutcomeObservation` with `source_type="work_state_transition"` and links it to the latest `SupportAttempt` whose `active_arc_id` matches that arc.
+- The saved observation records deterministic operational signals such as `task_started`, `blocker_resolved`, `open_loop_closed`, `arc_resumed`, or other explicitly mapped status transitions.
+- Re-saving unchanged state or writing state for an arc with no matching attempt does not fabricate or append observations.
+- Existing operational storage behavior still works when no support attempt is present.
+
+## Validation Workflow
+- **Workflow:** Python
+- **Static checks:** `uv run ruff check src/ tests/storage/test_support_learning_storage.py` and `uv run mypy --strict src/`
+- **Targeted tests:** run the smallest pytest command listed under each task
+
+---
+
+## Phase 1: Link operational transitions to the latest matching attempt
+
+### Persist deterministic work-state observations from public storage seams
+
+- [x] Test: add `test_sqlite_store_records_work_state_transition_observations_for_latest_matching_arc_attempt()` in `tests/storage/test_support_learning_storage.py` — verify task, blocker, open-loop, and arc transitions append ordered `work_state_transition` observations on the latest matching attempt for that arc.
+- [x] Implement: extend `src/alfred/storage/sqlite.py` with the minimal latest-attempt lookup, deterministic transition mapping, and observation persistence needed for `save_operational_arc()`, `save_arc_task()`, `save_arc_blocker()`, and `save_arc_open_loop()`.
+- [x] Run: `uv run pytest tests/storage/test_support_learning_storage.py::test_sqlite_store_records_work_state_transition_observations_for_latest_matching_arc_attempt -v`
+
+### Skip non-matching or non-transition writes cleanly
+
+- [x] Test: add `test_sqlite_store_skips_work_state_transition_observations_without_matching_arc_attempt_or_status_change()` in `tests/storage/test_support_learning_storage.py` — verify unmatched arcs and unchanged status upserts do not append observations.
+- [x] Implement: keep the new work-state observation path bounded so only explicitly mapped transitions on the matching arc produce new rows.
+- [x] Run: `uv run pytest tests/storage/test_support_learning_storage.py::test_sqlite_store_skips_work_state_transition_observations_without_matching_arc_attempt_or_status_change -v`
+
+---
+
+## Final phase verification
+
+- [x] Run: `uv run ruff check src/ tests/storage/test_support_learning_storage.py`
+- [x] Run: `uv run mypy --strict src/`
+- [x] Run: `uv run pytest tests/storage/test_support_learning_storage.py -v`
+
+## Files to Modify
+
+1. `prds/execution-plan-183-milestone3.md` - milestone plan and validation record
+2. `src/alfred/storage/sqlite.py` - latest-attempt lookup plus operational observation persistence from public work-state seams
+3. `tests/storage/test_support_learning_storage.py` - public storage-seam regression tests for deterministic work-state observations
+
+## Commit Strategy
+
+Keep this slice atomic:
+- `feat(storage): persist v2 work-state outcome observations`

--- a/prds/execution-plan-183-milestone4.md
+++ b/prds/execution-plan-183-milestone4.md
@@ -1,0 +1,61 @@
+# Execution Plan: PRD #183 - Milestone 4A: Deterministic case finalization from persisted attempt bundles
+
+## Overview
+Start Milestone 4 at the new public seam that already exists: persisted `SupportAttempt` plus appended `OutcomeObservation` rows. This slice adds one deterministic case-finalization contract that scores a stored attempt bundle into a durable `LearningCase`, without depending on new conversational producers or semantic extraction.
+
+## Current Repo Constraints
+- `src/alfred/support_policy.py` still applies the older `LearningSituation` bounded-adaptation path before generation; Milestone 4 must move toward `SupportAttempt` → `OutcomeObservation` → `LearningCase` without trying to replace the whole runtime in one jump.
+- `src/alfred/storage/sqlite.py` can already persist and load `SupportAttempt`, `OutcomeObservation`, and `LearningCase`, but there is no public helper that synthesizes a case from stored attempt evidence.
+- Milestone 3A now appends deterministic `work_state_transition` observations from public operational storage seams, so there is real persisted evidence to score even before conversational extraction lands.
+- Conversational and semantic observation producers remain out of scope for this slice; the scoring contract must work with whatever observations already exist.
+- The repo still has unrelated in-flight changes, so this slice should stay bounded to the support-learning model, SQLite store, tests, and milestone plan.
+
+## Success Signal
+- Given one stored `SupportAttempt` and its persisted observations, Alfred can derive one deterministic `LearningCase` with explicit scope, aggregate signals, evidence counts, channel scores, and promotion eligibility.
+- The SQLite store exposes one public seam that finalizes and persists that case for a specific attempt.
+- Attempts without any observations do not fabricate a finalized case.
+- Contradictory or neutral-only evidence remains inspectable through `LearningCase`, but only sufficiently positive, low-contradiction cases become promotion-eligible.
+
+## Validation Workflow
+- **Workflow:** Python
+- **Static checks:** `uv run ruff check src/ tests/test_support_learning.py tests/storage/test_support_learning_storage.py` and `uv run mypy --strict src/`
+- **Targeted tests:** run the smallest pytest command listed under each task
+
+---
+
+## Phase 1: Derive deterministic cases from persisted observations
+
+### Add a pure attempt-plus-observation case derivation contract
+
+- [x] Test: add `test_derive_learning_case_scores_conversational_and_operational_evidence()` in `tests/test_support_learning.py` — verify scope selection, aggregate signals, evidence counts, scores, and promotion eligibility for a positive mixed-source case.
+- [x] Test: add `test_derive_learning_case_marks_neutral_only_evidence_as_insufficient()` in `tests/test_support_learning.py` — verify neutral-only evidence finalizes as inspectable but not promotion-eligible.
+- [x] Implement: add the minimal deterministic case-derivation helpers in `src/alfred/memory/support_learning.py` for scoring observations into one `LearningCase`.
+- [x] Run: `uv run pytest tests/test_support_learning.py::test_derive_learning_case_scores_conversational_and_operational_evidence tests/test_support_learning.py::test_derive_learning_case_marks_neutral_only_evidence_as_insufficient -v`
+
+### Persist finalized cases from the SQLite public seam
+
+- [x] Test: add `test_sqlite_store_finalize_support_learning_case_persists_scored_case_from_attempt_observations()` in `tests/storage/test_support_learning_storage.py` — verify the store finalizes, persists, and returns the deterministic case for a stored attempt bundle.
+- [x] Test: add `test_sqlite_store_finalize_support_learning_case_skips_attempts_without_observations()` in `tests/storage/test_support_learning_storage.py` — verify missing or observation-free attempts do not fabricate finalized cases.
+- [x] Implement: extend `src/alfred/storage/sqlite.py` with the minimal attempt/observation loading and public case-finalization helper needed to persist the derived case.
+- [x] Run: `uv run pytest tests/storage/test_support_learning_storage.py::test_sqlite_store_finalize_support_learning_case_persists_scored_case_from_attempt_observations tests/storage/test_support_learning_storage.py::test_sqlite_store_finalize_support_learning_case_skips_attempts_without_observations -v`
+
+---
+
+## Final phase verification
+
+- [x] Run: `uv run ruff check src/ tests/test_support_learning.py tests/storage/test_support_learning_storage.py`
+- [x] Run: `uv run mypy --strict src/`
+- [x] Run: `uv run pytest tests/test_support_learning.py tests/storage/test_support_learning_storage.py -v`
+
+## Files to Modify
+
+1. `prds/execution-plan-183-milestone4.md` - milestone plan and validation record
+2. `src/alfred/memory/support_learning.py` - deterministic learning-case derivation helpers
+3. `src/alfred/storage/sqlite.py` - public case-finalization seam for one attempt bundle
+4. `tests/test_support_learning.py` - pure model scoring coverage for deterministic case derivation
+5. `tests/storage/test_support_learning_storage.py` - SQLite case-finalization regression coverage
+
+## Commit Strategy
+
+Keep this slice atomic:
+- `feat(memory): finalize v2 learning cases from observations`

--- a/prds/execution-plan-183-milestone4b.md
+++ b/prds/execution-plan-183-milestone4b.md
@@ -1,0 +1,49 @@
+# Execution Plan: PRD #183 - Milestone 4B (slice): Runtime resolves learned values from the v2 value ledger
+
+## Overview
+This slice begins the **runtime cutover** work by making the reply-time support-policy resolver prefer **v2 value-ledger entries** (case-derived learning) when loading learned support/relational values.
+
+We keep the change narrow by wiring the v2 ledger into an existing public seam:
+- `SQLiteStore.resolve_support_profile_value(...)`
+
+This avoids touching TUI surfaces and keeps the current support-policy contract stable.
+
+## Success Signal (observable)
+Given stored learning:
+- a v2 `SupportValueLedgerEntry` with status `active_auto` or `confirmed` for a `(registry, dimension, scope)`
+
+When runtime resolves learned values:
+- `SQLiteStore.resolve_support_profile_value(...)` returns an effective value matching the v2 ledger entry
+- v1 `support_profile_values` are still used as fallback when there is no active v2 entry
+
+## Repo Constraints
+- The support-policy runtime currently calls `SupportPolicyStore.resolve_support_profile_value(...)` for each dimension.
+- That protocol returns a **v1** `SupportProfileValue`.
+- v2 ledger entries live in `support_value_ledger_entries` and can contain multiple values per dimension (contradictions) but should have at most one active entry.
+
+## Design Decisions (this slice)
+- Only v2 statuses `active_auto` and `confirmed` are eligible to be returned to runtime.
+- v2 entries are adapted to a synthetic v1 `SupportProfileValue`:
+  - `status`: `confirmed`
+  - `source`: `auto_adapted`
+  - `evidence_refs`: `(last_case_id,)` when present
+  - timestamps + confidence: copied from the v2 entry
+- Precedence is:
+  1. scope specificity: `arc` → `context` → `global`
+  2. within each scope: v2 active entry → v1 stored profile value
+
+## Validation Workflow
+Python
+```bash
+uv run ruff check src/ tests/storage/test_support_profile_storage.py
+uv run mypy --strict src/
+uv run pytest tests/storage/test_support_profile_storage.py -v
+```
+
+## Tasks
+- [x] **Test-first:** add a storage test asserting that `resolve_support_profile_value()` prefers a v2 active value-ledger entry over a v1 profile value for the same `(registry, dimension, scope)`.
+- [x] **Implement:** update `SQLiteStore.resolve_support_profile_value()` to consult `support_value_ledger_entries` (active statuses only) before falling back to `support_profile_values`.
+- [x] **Run:** targeted ruff + mypy + pytest for the touched storage surface.
+
+## Commit Strategy
+- `feat(prd-183): runtime resolves values from v2 value ledger`

--- a/prds/execution-plan-183-milestone4b2.md
+++ b/prds/execution-plan-183-milestone4b2.md
@@ -1,0 +1,28 @@
+# Execution Plan: PRD #183 - Milestone 4B.2 (Option A): Retire bounded adaptation (`LearningSituation`) in runtime
+
+## Overview
+Milestone 4B.2 (Option A) removes the **turn-centric bounded adaptation** path from the reply-time runtime.
+
+This intentionally does **not** add any new semantic extraction or new promotion triggers.
+
+## Success Signal (observable)
+When `SupportPolicyRuntime.build_turn_contract()` is called with a `query_embedding`:
+- it does **not** persist `LearningSituation`
+- it does **not** write v1 support-profile update events/pattern candidates via bounded adaptation
+- the runtime still resolves values deterministically via defaults + stored scoped values (now including v2 ledger-derived values via `resolve_support_profile_value`)
+
+## Validation Workflow
+Python
+```bash
+uv run ruff check src/ tests/test_support_policy.py
+uv run mypy --strict src/
+uv run pytest tests/test_support_policy.py -v
+```
+
+## Tasks
+- [x] **Test-first:** update `tests/test_support_policy.py` to assert that the runtime no longer persists learning situations / bounded adaptation artifacts.
+- [x] **Implement:** turn `SupportPolicyRuntime._maybe_apply_bounded_adaptation(...)` into a no-op and remove the post-adaptation second-pass resolve.
+- [x] **Run:** targeted ruff + mypy + pytest.
+
+## Commit Strategy
+- `feat(prd-183): retire bounded adaptation runtime path`

--- a/prds/execution-plan-183-milestone4b3.md
+++ b/prds/execution-plan-183-milestone4b3.md
@@ -1,0 +1,98 @@
+# Execution Plan: PRD #183 - Milestone 4B.3: Apply v2 case-learning from operational observations
+
+## Overview
+Now that bounded adaptation (`LearningSituation`) is retired (4B.2) and runtime value resolution prefers v2 ledger entries (4B.1), we need a deterministic **runner** that turns the operational observation lane (3A) into finalized cases (4A) and value-ledger updates (5A).
+
+This phase is **operational-only**: it reacts to `work_state_transition` observations written via the existing public SQLite work-state seams.
+
+## Current Repo Constraints
+- Work-state writes (`save_operational_arc`, `save_arc_task`, `save_arc_blocker`, `save_arc_open_loop`) open an `aiosqlite` connection and commit at the end.
+- `_maybe_save_work_state_transition_observation(...)` currently inserts an `OutcomeObservation` inside that same connection, but does **not** finalize a `LearningCase` or apply case-based ledger learning.
+- Public helpers `finalize_support_learning_case(attempt_id)` and `apply_support_case_learning(case_id)` currently open their **own** SQLite connections and commit. Calling them from inside a work-state write would cross transaction boundaries and risks seeing partial state.
+- Case-based ledger promotion requires `LearningCase.status == "complete"` and `promotion_eligibility == True`. With a single strong positive operational signal (e.g. `task_completed`), a case should become promotable, but the derived ledger entry should still be `shadow` until the per-scope threshold is met.
+- Conversational/semantic extraction is explicitly out of scope for PRD #183 (owned by PRD #189).
+
+## Success Signal (observable)
+When a work-state write produces a `work_state_transition` observation for a matching `SupportAttempt`:
+1. A `LearningCase` is finalized/upserted for that attempt (`case-{attempt_id}`).
+2. Case-based learning is applied for that case, persisting:
+   - at least one v2 `support_value_ledger_entries` row (typically `status="shadow"` on first evidence)
+   - at least one v2 `support_ledger_update_events` row describing the new/changed status.
+
+And when the work-state write produces **no** observation (no transition signal or no matching attempt), no case/ledger writes occur.
+
+## Validation Workflow
+**Python**
+
+- Static checks:
+  ```bash
+  uv run ruff check src/ tests/storage/test_support_learning_storage.py
+  uv run mypy --strict src/
+  ```
+- Targeted tests:
+  ```bash
+  uv run pytest tests/storage/test_support_learning_storage.py -v
+  ```
+
+---
+
+## Phase 1: End-to-end storage contract from work-state transition → ledger rows
+
+### SQLite work-state seam
+
+- [x] Test: `test_sqlite_store_work_state_transition_finalizes_case_and_applies_v2_value_ledger_updates()` in `tests/storage/test_support_learning_storage.py`
+  - Arrange: persisted `SupportAttempt` for an arc + persisted operational arc/task
+  - Act: perform a status change that yields a known positive signal (e.g. task `todo` → `done`)
+  - Assert:
+    - one `OutcomeObservation(source_type="work_state_transition")` exists for the attempt
+    - `get_support_learning_case("case-{attempt_id}")` exists and is `promotion_eligibility == True`
+    - `list_support_value_ledger_entries()` contains a derived entry with:
+      - `source == "auto_case"`
+      - `status == "shadow"` (first promotable case)
+      - `scope.type == "arc"` and `scope.id == attempt.active_arc_id`
+    - `list_support_ledger_update_events()` contains a new event with `new_status == "shadow"` and `trigger_case_ids` containing the case id
+
+- [x] Implement: run case finalization + case-learning inside `_maybe_save_work_state_transition_observation(...)` using the *existing* `db` connection
+  - Add internal transactional helpers:
+    - `_finalize_support_learning_case_in_tx(db, attempt_id) -> LearningCase | None`
+    - `_apply_support_case_learning_in_tx(db, case_id) -> SupportLedgerDerivationResult | None`
+  - Refactor the public methods:
+    - `finalize_support_learning_case(attempt_id)` should open a connection and delegate to `_finalize_support_learning_case_in_tx(...)` then commit.
+    - `apply_support_case_learning(case_id)` should open a connection and delegate to `_apply_support_case_learning_in_tx(...)` then commit.
+  - In `_maybe_save_work_state_transition_observation(...)`, after inserting the observation:
+    - finalize the case for `attempt.attempt_id`
+    - if the case is promotable, apply case learning for `case.case_id`
+    - do **not** commit inside this helper; rely on the surrounding work-state save method’s commit.
+
+- [x] Run: `uv run pytest tests/storage/test_support_learning_storage.py::test_sqlite_store_work_state_transition_finalizes_case_and_applies_v2_value_ledger_updates -v`
+
+---
+
+## Phase 2: Negative-path guard (no transition/no attempt)
+
+- [x] Test: `test_sqlite_store_work_state_transition_does_not_apply_case_learning_when_no_observation_is_written()` in `tests/storage/test_support_learning_storage.py`
+  - Arrange: persisted arc/task but either:
+    - no matching attempt for the arc, or
+    - status update that does not produce a transition signal
+  - Assert: `list_support_value_ledger_entries()` and `list_support_ledger_update_events()` remain empty and no `support_learning_cases` row is created.
+
+- [x] Implement: ensure `_maybe_save_work_state_transition_observation(...)` only triggers finalize/apply when an observation was actually upserted (and an attempt exists).
+
+- [x] Run: `uv run pytest tests/storage/test_support_learning_storage.py::test_sqlite_store_work_state_transition_does_not_apply_case_learning_when_no_observation_is_written -v`
+
+---
+
+## Final phase verification
+
+- [x] Run: `uv run ruff check src/ tests/storage/test_support_learning_storage.py`
+- [x] Run: `uv run mypy --strict src/`
+- [x] Run: `uv run pytest tests/storage/test_support_learning_storage.py -v`
+
+## Files to Modify
+1. `src/alfred/storage/sqlite.py` - apply finalize+case-learning during operational observation writes; add transactional helpers
+2. `tests/storage/test_support_learning_storage.py` - end-to-end contract tests for work-state-driven case+ledger updates
+
+## Commit Strategy
+Two atomic commits:
+1. `test(prd-183): prove work-state transitions finalize cases and write v2 ledger rows`
+2. `feat(prd-183): apply case learning during work-state observation writes`

--- a/prds/execution-plan-183-milestone5.md
+++ b/prds/execution-plan-183-milestone5.md
@@ -1,0 +1,73 @@
+# Execution Plan: PRD #183 - Milestone 5A: Case-based value ledger promotion from finalized cases
+
+## Overview
+Start Milestone 5 at the narrowest promotion seam that now exists: finalized `LearningCase` records plus their source `SupportAttempt` bundles. This slice promotes support and relational values into the v2 value ledger with explicit `shadow` and `active_auto` statuses, while deferring patterns, demotion, runtime rewiring, and cross-scope generalization.
+
+## Current Repo Constraints
+- `src/alfred/support_policy.py` still uses the older `LearningSituation` bounded-adaptation path before generation, so this slice must establish case-based ledger derivation without replacing runtime loading yet.
+- `src/alfred/memory/support_learning.py` can now derive deterministic `LearningCase` records, but a case alone does not identify which values Alfred applied; Milestone 5A must join each finalized case back to its source `SupportAttempt`.
+- `src/alfred/storage/sqlite.py` already persists `SupportValueLedgerEntry` and `SupportLedgerUpdateEvent`, but no public seam yet derives those rows from finalized case bundles.
+- This slice should stay exact-scope only: `arc` and `context` scopes may promote, while `global`, cross-arc rollup, demotion, retirement, and pattern inference stay out of scope.
+- The product decision for this slice is to persist below-threshold evidence as inspectable `shadow` rows rather than discarding it.
+- The repo still has unrelated in-flight changes, so keep this work bounded to support-learning models, storage, tests, and PRD planning docs.
+
+## Success Signal
+- Given finalized case bundles in one exact scope, Alfred can derive deterministic `SupportValueLedgerEntry` rows for the values actually used in those attempts and persist them as `shadow` or `active_auto` based on repeated promotable evidence.
+- Arc-scoped values promote after two supporting promotable cases, while context-scoped values require four.
+- Conflicting same-scope values on the same dimension increase `contradiction_count` and block `active_auto` when support is not stronger than contradiction.
+- The SQLite store exposes one public seam that applies case-based learning for a finalized case and writes the resulting value-ledger rows and update events transactionally.
+- Missing, unfinalized, or non-promotable case bundles do not fabricate ledger rows or events.
+
+## Validation Workflow
+- **Workflow:** Python
+- **Static checks:** `uv run ruff check src/ tests/test_support_learning.py tests/storage/test_support_learning_storage.py` and `uv run mypy --strict src/`
+- **Targeted tests:** run the smallest pytest command listed under each task
+
+---
+
+## Phase 1: Derive exact-scope value-ledger updates from finalized case bundles
+
+### Persist inspectable shadow rows before promotion thresholds are met
+
+- [x] Test: add `test_derive_value_ledger_updates_persists_shadow_rows_below_exact_scope_thresholds()` in `tests/test_support_learning.py` — verify one promotable arc-scoped support value and one promotable context-scoped relational value persist as `shadow` with evidence counts, confidence, and update events.
+- [x] Implement: add the minimal finalized-case bundle type plus pure exact-scope value-ledger derivation in `src/alfred/memory/support_learning.py`.
+- [x] Run: `uv run pytest tests/test_support_learning.py::test_derive_value_ledger_updates_persists_shadow_rows_below_exact_scope_thresholds -v`
+
+### Promote repeated scoped values and count contradictions deterministically
+
+- [x] Test: add `test_derive_value_ledger_updates_promotes_after_threshold_and_blocks_when_conflicts_win()` in `tests/test_support_learning.py` — verify a second supporting arc case promotes the same value to `active_auto`, while conflicting same-dimension evidence increases contradiction counts and blocks activation when support is not stronger.
+- [x] Implement: extend the pure derivation logic with exact-scope thresholds, contradiction counting, and status transitions for existing value-ledger rows.
+- [x] Run: `uv run pytest tests/test_support_learning.py::test_derive_value_ledger_updates_promotes_after_threshold_and_blocks_when_conflicts_win -v`
+
+### Apply finalized-case learning through the SQLite public seam
+
+- [x] Test: add `test_sqlite_store_apply_support_case_learning_persists_shadow_then_active_auto_updates()` in `tests/storage/test_support_learning_storage.py` — verify applying learning for one finalized case writes `shadow` rows and events, then a second supporting finalized case upgrades the same scoped value to `active_auto`.
+- [x] Implement: extend `src/alfred/storage/sqlite.py` with the minimal attempt/case bundle loading and transactional `apply_support_case_learning(case_id)` seam needed to persist derived value-ledger rows and update events.
+- [x] Run: `uv run pytest tests/storage/test_support_learning_storage.py::test_sqlite_store_apply_support_case_learning_persists_shadow_then_active_auto_updates -v`
+
+### Skip missing or non-applicable case bundles cleanly
+
+- [x] Test: add `test_sqlite_store_apply_support_case_learning_skips_missing_or_non_promotable_cases()` in `tests/storage/test_support_learning_storage.py` — verify missing cases, unfinalized cases, and non-promotable finalized bundles do not fabricate ledger rows or events.
+- [x] Implement: keep the new storage seam bounded so only finalized promotable case bundles with resolvable attempts write ledger updates.
+- [x] Run: `uv run pytest tests/storage/test_support_learning_storage.py::test_sqlite_store_apply_support_case_learning_skips_missing_or_non_promotable_cases -v`
+
+---
+
+## Final phase verification
+
+- [x] Run: `uv run ruff check src/ tests/test_support_learning.py tests/storage/test_support_learning_storage.py`
+- [x] Run: `uv run mypy --strict src/`
+- [x] Run: `uv run pytest tests/test_support_learning.py tests/storage/test_support_learning_storage.py -v`
+
+## Files to Modify
+
+1. `prds/execution-plan-183-milestone5.md` - milestone plan and validation record
+2. `src/alfred/memory/support_learning.py` - pure finalized-case bundle derivation for v2 value-ledger updates
+3. `src/alfred/storage/sqlite.py` - public transactional seam that applies case-based value learning
+4. `tests/test_support_learning.py` - pure model coverage for thresholds, contradictions, and shadow persistence
+5. `tests/storage/test_support_learning_storage.py` - SQLite regression coverage for case-based value-ledger writes
+
+## Commit Strategy
+
+Keep this slice atomic:
+- `feat(memory): derive v2 value ledger updates from finalized cases`

--- a/prds/execution-plan-183-milestone6.md
+++ b/prds/execution-plan-183-milestone6.md
@@ -1,0 +1,157 @@
+# Execution Plan: PRD #183 - Milestone 6A (Web UI only): Inspect v2 value ledger entries via `/context`
+
+## Overview
+Ship the first **Web UI-only** inspection surface for PRD #183’s v2 learning artifacts by extending the existing `/context` → `context.info` payload and rendering the full v2 **value ledger** (support + relational) inside the Web UI `context-viewer`.
+
+This slice is intentionally **not a TUI feature**: no new TUI commands, no CLI rendering changes. The Web UI will surface the data using the existing `/context` command path.
+
+### What this slice covers
+- v2 **SupportValueLedgerEntry** inspection (all statuses: `shadow`, `active_auto`, `confirmed`, `rejected`, `retired`)
+- v2 **SupportLedgerUpdateEvent** inspection (recent events; value-entity focused)
+- Web UI rendering inside the existing **Support State** section of `context-viewer`
+
+### What this slice explicitly defers
+- `/support values` TUI command and rendering
+- `/support cases`, `/support trace`, `/support patterns`
+- pattern inference display
+- runtime rewiring to load v2 values (this is inspection only)
+
+
+## Current Repo Constraints
+- The Web UI receives `/context` via WebSocket (`command.execute` → `context.info`) and renders it using `src/alfred/interfaces/webui/static/js/components/context-viewer.js`.
+- `src/alfred/context_display.py` builds `support_state` by calling `SupportReflectionRuntime.build_inspection_snapshot()`.
+- `SupportReflectionRuntime` currently surfaces patterns + v1 update events, but **does not** include v2 value-ledger entries nor v2 ledger-update events.
+- SQLite persistence already exists for:
+  - `SupportValueLedgerEntry` (`support_value_ledger_entries`)
+  - `SupportLedgerUpdateEvent` (`support_ledger_update_events`)
+- This milestone must avoid expanding scope into TUI command plumbing.
+
+
+## Success Signal (observable)
+In the Web UI:
+1. User enters `/context`.
+2. The resulting `context.info.payload.support_state.learned_state` includes:
+   - `value_ledger_entries` (bounded list, deterministic order)
+   - `value_ledger_summary` (counts by status + totals)
+   - `recent_ledger_update_events` (bounded list)
+3. `context-viewer` renders a **Value Ledger** card under **Support State**, listing ledger entries with:
+   - registry, dimension, scope, value, status, confidence, evidence_count, contradiction_count
+   - (optional) expandable “why” text
+4. The view is deterministic and does not require any TUI changes.
+
+
+## Validation Workflow
+**Workflow:** Python + JavaScript
+
+Python checks:
+```bash
+uv run ruff check src/ tests/test_support_reflection.py tests/webui/test_server_parity.py
+uv run mypy --strict src/
+uv run pytest \
+  tests/test_support_reflection.py \
+  tests/webui/test_server_parity.py \
+  -v
+```
+
+JavaScript checks:
+```bash
+npm run js:check
+```
+
+Browser verification (targeted, slow):
+```bash
+uv run pytest tests/webui/test_support_value_ledger_browser.py -v
+```
+
+
+---
+
+## Phase 1: Add v2 value-ledger inspection data to the `/context` payload
+
+### Extend support-inspection snapshot to include v2 values + v2 ledger events
+
+- [x] **Test (Python):** extend `tests/test_support_reflection.py` with `test_support_inspection_snapshot_includes_v2_value_ledger_entries_and_recent_ledger_events()`.
+  - Use the existing `FakeReflectionStore` pattern.
+  - Provide fake v2 `SupportValueLedgerEntry` rows spanning multiple statuses.
+  - Provide fake v2 `SupportLedgerUpdateEvent` rows.
+  - Assert `SupportReflectionRuntime.build_inspection_snapshot()` returns them in deterministic order and with correct counts.
+
+- [x] **Implement (Python):** extend `src/alfred/support_reflection.py`:
+  - extend `LearnedState` with:
+    - `value_ledger_entries: tuple[SupportValueLedgerEntrySummary, ...]` (summary DTO, not the raw DB record)
+    - `value_ledger_summary: {total, counts_by_status, counts_by_registry}` (exact shape defined in test)
+    - `recent_ledger_update_events: tuple[LedgerUpdateEventSummary, ...]`
+  - extend `SupportReflectionStore` protocol to support loading:
+    - `list_support_value_ledger_entries(...)` (bounded)
+    - `list_support_ledger_update_events(...)` (bounded)
+  - wire `SupportReflectionRuntime.build_inspection_snapshot()` to call these store methods and populate the new fields.
+
+- [x] **Run:** `uv run pytest tests/test_support_reflection.py::test_support_inspection_snapshot_includes_v2_value_ledger_entries_and_recent_ledger_events -v`
+
+### Ensure `/context` display forwards the new fields
+
+- [ ] **Test (Python):** extend `tests/test_context_display.py` (or add a focused new test) to assert that `get_context_display()`’s `support_state` payload includes the new learned-state fields when the reflection runtime provides them.
+  - Keep this as a narrow “serialization contract” test (no DB required).
+
+- [ ] **Implement (Python):** update `src/alfred/context_display.py` to serialize the new v2 ledger summary fields into the `support_state.learned_state` dict.
+
+
+---
+
+## Phase 2: Render the value ledger in the Web UI (no TUI changes)
+
+### Add DOM rendering for ledger entries
+
+- [ ] **Test (browser / Playwright, slow):** add `tests/webui/test_support_value_ledger_browser.py`.
+  - Start the Web UI server with `create_app(FakeAlfred())`.
+  - Patch `alfred.context_display.get_context_display` to return a `context_data` payload that includes:
+    - `support_state.learned_state.value_ledger_entries`
+    - `support_state.learned_state.value_ledger_summary`
+    - `support_state.learned_state.recent_ledger_update_events`
+  - In the browser:
+    - send `/context`
+    - assert the page renders a “Value Ledger” card and shows at least one expected ledger entry (registry + dimension + value + status).
+
+- [ ] **Implement (JavaScript):** update `src/alfred/interfaces/webui/static/js/components/context-viewer.js`
+  - Extend `_renderSupportState()` to include a new card, e.g. “Value Ledger”.
+  - Render each entry with status badge and confidence.
+  - Keep deterministic ordering as provided by the payload.
+  - Keep UI minimal: no fancy filtering in 6A unless required by test.
+
+- [ ] **Run:**
+  - `npm run js:check`
+  - `uv run pytest tests/webui/test_support_value_ledger_browser.py -v`
+
+
+---
+
+## Phase 3: WebSocket protocol docs alignment
+
+- [ ] **Docs:** update `docs/websocket-protocol.md` `context.info` payload description to mention the new `support_state.learned_state.value_ledger_entries` and `recent_ledger_update_events` fields.
+
+
+---
+
+## Final phase verification
+
+- [ ] Run: `uv run ruff check src/ tests/test_support_reflection.py tests/webui/test_server_parity.py`
+- [ ] Run: `uv run mypy --strict src/`
+- [ ] Run: `uv run pytest tests/test_support_reflection.py tests/test_context_display.py tests/webui/test_server_parity.py -v`
+- [ ] Run: `npm run js:check`
+- [ ] Run (slow): `uv run pytest tests/webui/test_support_value_ledger_browser.py -v`
+
+
+## Files to Modify
+- `prds/execution-plan-183-milestone6.md`
+- `src/alfred/support_reflection.py`
+- `src/alfred/context_display.py`
+- `src/alfred/interfaces/webui/static/js/components/context-viewer.js`
+- `docs/websocket-protocol.md`
+- `tests/test_support_reflection.py`
+- `tests/test_context_display.py` (or a new narrow serialization test)
+- `tests/webui/test_support_value_ledger_browser.py`
+
+
+## Commit Strategy
+Keep this slice atomic:
+- `feat(prd-183): webui renders v2 support value ledger in context viewer`

--- a/prds/execution-plan-183-milestone6.md
+++ b/prds/execution-plan-183-milestone6.md
@@ -90,10 +90,10 @@ uv run pytest tests/webui/test_support_value_ledger_browser.py -v
 
 ### Ensure `/context` display forwards the new fields
 
-- [ ] **Test (Python):** extend `tests/test_context_display.py` (or add a focused new test) to assert that `get_context_display()`’s `support_state` payload includes the new learned-state fields when the reflection runtime provides them.
+- [x] **Test (Python):** extend `tests/test_context_display.py` (or add a focused new test) to assert that `get_context_display()`’s `support_state` payload includes the new learned-state fields when the reflection runtime provides them.
   - Keep this as a narrow “serialization contract” test (no DB required).
 
-- [ ] **Implement (Python):** update `src/alfred/context_display.py` to serialize the new v2 ledger summary fields into the `support_state.learned_state` dict.
+- [x] **Implement (Python):** update `src/alfred/context_display.py` to serialize the new v2 ledger summary fields into the `support_state.learned_state` dict.
 
 
 ---

--- a/prds/execution-plan-183-milestone6.md
+++ b/prds/execution-plan-183-milestone6.md
@@ -102,7 +102,7 @@ uv run pytest tests/webui/test_support_value_ledger_browser.py -v
 
 ### Add DOM rendering for ledger entries
 
-- [ ] **Test (browser / Playwright, slow):** add `tests/webui/test_support_value_ledger_browser.py`.
+- [x] **Test (browser / Playwright, slow):** add `tests/webui/test_support_value_ledger_browser.py`.
   - Start the Web UI server with `create_app(FakeAlfred())`.
   - Patch `alfred.context_display.get_context_display` to return a `context_data` payload that includes:
     - `support_state.learned_state.value_ledger_entries`
@@ -112,13 +112,13 @@ uv run pytest tests/webui/test_support_value_ledger_browser.py -v
     - send `/context`
     - assert the page renders a “Value Ledger” card and shows at least one expected ledger entry (registry + dimension + value + status).
 
-- [ ] **Implement (JavaScript):** update `src/alfred/interfaces/webui/static/js/components/context-viewer.js`
+- [x] **Implement (JavaScript):** update `src/alfred/interfaces/webui/static/js/components/context-viewer.js`
   - Extend `_renderSupportState()` to include a new card, e.g. “Value Ledger”.
   - Render each entry with status badge and confidence.
   - Keep deterministic ordering as provided by the payload.
   - Keep UI minimal: no fancy filtering in 6A unless required by test.
 
-- [ ] **Run:**
+- [x] **Run:**
   - `npm run js:check`
   - `uv run pytest tests/webui/test_support_value_ledger_browser.py -v`
 
@@ -127,7 +127,7 @@ uv run pytest tests/webui/test_support_value_ledger_browser.py -v
 
 ## Phase 3: WebSocket protocol docs alignment
 
-- [ ] **Docs:** update `docs/websocket-protocol.md` `context.info` payload description to mention the new `support_state.learned_state.value_ledger_entries` and `recent_ledger_update_events` fields.
+- [x] **Docs:** update `docs/websocket-protocol.md` `context.info` payload description to mention the new `support_state.learned_state.value_ledger_entries` and `recent_ledger_update_events` fields.
 
 
 ---

--- a/src/alfred/alfred.py
+++ b/src/alfred/alfred.py
@@ -689,11 +689,7 @@ class Alfred:
             session.meta.message_count = len(session.messages)
 
             support_runtime = self._get_support_policy_runtime()
-            save_support_attempt = (
-                getattr(support_runtime, "save_support_attempt", None)
-                if support_runtime is not None
-                else None
-            )
+            save_support_attempt = getattr(support_runtime, "save_support_attempt", None) if support_runtime is not None else None
             should_save_support_attempt = support_runtime_result is not None and callable(save_support_attempt)
 
             # Persist to storage

--- a/src/alfred/alfred.py
+++ b/src/alfred/alfred.py
@@ -328,22 +328,26 @@ class Alfred:
             resolved_session_id = session.meta.session_id
 
             messages_list = self.core.session_manager.get_session_messages(session_id)
+            user_message_id: str | None = None
             if reuse_user_message and messages_list:
                 last_message = messages_list[-1]
                 if last_message.role is Role.USER:
                     user_msg_idx = last_message.idx
+                    user_message_id = last_message.id
                     msg_count = len(messages_list)
                     logger.debug(f"Reusing user message. Session has {msg_count} messages")
                 else:
                     self.core.session_manager.add_message("user", message, session_id=session_id)
                     messages_list = self.core.session_manager.get_session_messages(session_id)
                     user_msg_idx = messages_list[-1].idx if messages_list else 0
+                    user_message_id = messages_list[-1].id if messages_list else None
                     msg_count = len(messages_list)
                     logger.debug(f"Added user message. Session now has {msg_count} messages")
             else:
                 self.core.session_manager.add_message("user", message, session_id=session_id)
                 messages_list = self.core.session_manager.get_session_messages(session_id)
                 user_msg_idx = messages_list[-1].idx if messages_list else 0
+                user_message_id = messages_list[-1].id if messages_list else None
                 msg_count = len(messages_list)
                 logger.debug(f"Added user message. Session now has {msg_count} messages")
 
@@ -394,7 +398,7 @@ class Alfred:
                 duration_ms=round((perf_counter() - context_started_at) * 1000, 2),
             )
 
-            support_contract_section = await self._build_support_contract_section_for_turn(
+            support_contract_section, support_runtime_result = await self._build_support_contract_section_for_turn(
                 message=message,
                 query_embedding=query_embedding,
                 session_messages=session_messages,
@@ -684,8 +688,19 @@ class Alfred:
             session.meta.last_active = datetime.now(UTC)
             session.meta.message_count = len(session.messages)
 
+            support_runtime = self._get_support_policy_runtime()
+            save_support_attempt = (
+                getattr(support_runtime, "save_support_attempt", None)
+                if support_runtime is not None
+                else None
+            )
+            should_save_support_attempt = support_runtime_result is not None and callable(save_support_attempt)
+
             # Persist to storage
-            if persist_partial:
+            if should_save_support_attempt:
+                boundary = "persist"
+                await self.core.session_manager._persist_messages_strict(session.meta.session_id, session.messages)
+            elif persist_partial:
                 boundary = "persist"
                 await self.core.session_manager._persist_messages(session.meta.session_id, session.messages)
             else:
@@ -694,6 +709,20 @@ class Alfred:
             assistant_msg_idx = assistant_msg_obj.idx
             msg_count = len(session.messages)
             logger.debug(f"Added assistant message. Session now has {msg_count} messages")
+
+            if should_save_support_attempt:
+                if user_message_id is None:
+                    raise RuntimeError("Support attempt persistence requires a real user message id")
+                if assistant_msg_obj.id is None:
+                    raise RuntimeError("Support attempt persistence requires a real assistant message id")
+                boundary = "persist"
+                await cast(Callable[..., Any], save_support_attempt)(
+                    runtime_result=support_runtime_result,
+                    session_id=resolved_session_id,
+                    user_message_id=user_message_id,
+                    assistant_message_id=assistant_msg_obj.id,
+                    created_at=assistant_msg_obj.timestamp,
+                )
 
             # Store actual token counts with the messages
             if self._last_usage:
@@ -848,11 +877,11 @@ You can then continue the conversation with the tool results.
         query_embedding: list[float] | None,
         session_messages: list[tuple[str, str]],
         session_id: str | None,
-    ) -> str | None:
-        """Build the runtime support and reflection sections for one live turn when available."""
+    ) -> tuple[str | None, Any | None]:
+        """Build the runtime support/reflection section plus the runtime result for one live turn."""
         runtime = self._get_support_policy_runtime()
         if runtime is None:
-            return None
+            return (None, None)
 
         build_turn_contract = getattr(runtime, "build_turn_contract", None)
         reflection_runtime = self._get_support_reflection_runtime()
@@ -874,13 +903,16 @@ You can then continue the conversation with the tool results.
                 )
                 if reflection_section:
                     sections.append(reflection_section)
-            return "\n\n".join(section for section in sections if section)
+            return ("\n\n".join(section for section in sections if section), runtime_result)
 
-        return await runtime.build_prompt_section(
-            message=message,
-            query_embedding=query_embedding,
-            session_messages=session_messages,
-            session_id=session_id,
+        return (
+            await runtime.build_prompt_section(
+                message=message,
+                query_embedding=query_embedding,
+                session_messages=session_messages,
+                session_id=session_id,
+            ),
+            None,
         )
 
     async def get_support_snapshot_text(

--- a/src/alfred/context.py
+++ b/src/alfred/context.py
@@ -479,6 +479,7 @@ class ContextLoader:
         self._context_builder: ContextBuilder | None = None
         self._blocked_context_files: set[str] = set()
         self._disabled_sections: set[str] = set()  # Track disabled context sections
+        self._prompt_template_sync_lock = asyncio.Lock()
         if store:
             self._context_builder = ContextBuilder(
                 store,
@@ -566,6 +567,25 @@ class ContextLoader:
         except Exception as exc:
             logger.warning(f"Failed to reconcile template {template_name}: {exc}")
 
+    async def _sync_prompt_templates(self) -> None:
+        """Reconcile managed prompt fragments before resolving include placeholders."""
+        async with self._prompt_template_sync_lock:
+            loop = asyncio.get_running_loop()
+            try:
+                await loop.run_in_executor(None, self._template_manager.ensure_prompts_exist)
+                await loop.run_in_executor(None, self._template_manager.reconcile_prompt_templates)
+            except Exception as exc:
+                logger.warning("Failed to synchronize managed prompt fragments: %s", exc)
+
+    def _prompt_conflict_reason(self, path: Path, conflicted_dependencies: list[str]) -> str:
+        """Describe why a top-level context file is blocked by prompt fragment conflicts."""
+        owner_label = path.name or path.as_posix()
+        if len(conflicted_dependencies) == 1:
+            dependency = conflicted_dependencies[0]
+            return f"Conflicted managed prompt fragment {dependency} blocks {owner_label}"
+        joined = ", ".join(conflicted_dependencies)
+        return f"Conflicted managed prompt fragments block {owner_label}: {joined}"
+
     async def load_file(self, name: str, path: Path) -> ContextFile:
         """Load a context file, auto-creating from template if missing."""
         template_name = CONTEXT_TO_TEMPLATE.get(name)
@@ -583,10 +603,8 @@ class ContextLoader:
             return blocked
 
         cached = self._cache.get(name)
-        if cached is not None and (not is_managed_template or sync_record is None or not sync_record.is_conflicted()):
-            return self._refresh_context_file(cached)
 
-        self._template_manager.ensure_prompts_exist()
+        await self._sync_prompt_templates()
         self._reconcile_template(name)
 
         if is_managed_template and template_name is not None:
@@ -619,6 +637,34 @@ class ContextLoader:
         loop = asyncio.get_running_loop()
         raw_content = await loop.run_in_executor(None, path.read_text, "utf-8")
         stat = await loop.run_in_executor(None, path.stat)
+        last_modified = datetime.fromtimestamp(stat.st_mtime)
+
+        managed_prompt_dependencies = await loop.run_in_executor(
+            None,
+            self._template_manager.collect_managed_prompt_dependencies,
+            raw_content,
+        )
+        conflicted_prompt_dependencies = await loop.run_in_executor(
+            None,
+            self._template_manager.get_conflicted_prompt_dependencies,
+            raw_content,
+        )
+        if conflicted_prompt_dependencies:
+            reason = self._prompt_conflict_reason(path, conflicted_prompt_dependencies)
+            logger.warning("Blocked context file %s because %s", name, reason)
+            blocked = self._make_blocked_context_file(
+                name=name,
+                path=path,
+                reason=reason,
+                last_modified=last_modified,
+            )
+            self._record_blocked_context_file(name)
+            return blocked
+
+        if cached is not None and cached.last_modified == last_modified and not managed_prompt_dependencies:
+            self._clear_blocked_context_file(name)
+            return self._refresh_context_file(cached)
+
         static_content = resolve_all(raw_content, self.config.workspace_dir, resolve_volatile=False)
         refresh_on_load = has_volatile_placeholder(static_content)
 
@@ -626,7 +672,7 @@ class ContextLoader:
             name=name,
             path=str(path),
             content=static_content,
-            last_modified=datetime.fromtimestamp(stat.st_mtime),
+            last_modified=last_modified,
             state=ContextFileState.ACTIVE,
             refresh_on_load=refresh_on_load,
         )

--- a/src/alfred/context_display.py
+++ b/src/alfred/context_display.py
@@ -7,6 +7,7 @@ for user inspection via the /context command.
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -17,6 +18,52 @@ if TYPE_CHECKING:
     from alfred.alfred import Alfred
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class ContextConflictStatus:
+    """Structured record for one blocked/conflicted context file."""
+
+    id: str
+    name: str
+    label: str
+    reason: str
+
+    def to_payload(self) -> dict[str, str]:
+        """Serialize to the existing JSON-friendly payload shape."""
+        return {
+            "id": self.id,
+            "name": self.name,
+            "label": self.label,
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ContextStatus:
+    """Typed snapshot of current context health for UI/status surfaces."""
+
+    blocked_context_files: list[str] = field(default_factory=list)
+    conflicted_context_files: list[ContextConflictStatus] = field(default_factory=list)
+    disabled_sections: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    def to_display_payload(self) -> dict[str, Any]:
+        """Serialize to the snake_case /context payload shape."""
+        return {
+            "blocked_context_files": list(self.blocked_context_files),
+            "conflicted_context_files": [item.to_payload() for item in self.conflicted_context_files],
+            "disabled_sections": list(self.disabled_sections),
+            "warnings": list(self.warnings),
+        }
+
+    def to_websocket_payload(self) -> dict[str, Any]:
+        """Serialize to the camelCase status.update payload shape."""
+        return {
+            "blockedContextFiles": list(self.blocked_context_files),
+            "conflictedContextFiles": [item.to_payload() for item in self.conflicted_context_files],
+            "warnings": list(self.warnings),
+        }
 
 
 def _estimate_tokens(text: str) -> int:
@@ -222,6 +269,45 @@ async def _get_support_state_display(alfred: Alfred) -> dict[str, Any]:
     }
 
 
+def _build_context_status(
+    context_files: dict[str, Any],
+    disabled_sections: list[str],
+) -> ContextStatus:
+    """Build the shared blocked/conflicted context status snapshot."""
+    conflicted_context_files = [
+        ContextConflictStatus(
+            id=_context_file_identifier(file),
+            name=_context_file_identifier(file),
+            label=_context_file_name(file),
+            reason=getattr(file, "blocked_reason", None) or "Blocked context file",
+        )
+        for file in context_files.values()
+        if getattr(file, "is_blocked", lambda: False)()
+    ]
+    if conflicted_context_files:
+        logger.debug("context_status: found %d conflicted context files", len(conflicted_context_files))
+
+    warnings: list[str] = []
+    if disabled_sections:
+        warnings.append(f"Disabled sections: {', '.join(disabled_sections)}")
+
+    return ContextStatus(
+        blocked_context_files=[file.label for file in conflicted_context_files],
+        conflicted_context_files=conflicted_context_files,
+        disabled_sections=list(disabled_sections),
+        warnings=warnings,
+    )
+
+
+async def get_context_status(alfred: Alfred) -> ContextStatus:
+    """Get the lightweight context-health snapshot used by Web UI status updates."""
+    logger.debug("get_context_status: gathering current context health")
+    disabled_sections = alfred.context_loader.get_disabled_sections()
+    context_files = await alfred.context_loader.load_all()
+    logger.debug("get_context_status: loaded %d context files", len(context_files))
+    return _build_context_status(context_files, disabled_sections)
+
+
 async def get_context_display(alfred: Alfred, session_id: str | None = None) -> dict[str, Any]:
     """Get current context information for /context command.
 
@@ -247,23 +333,10 @@ async def get_context_display(alfred: Alfred, session_id: str | None = None) -> 
     context_files = await alfred.context_loader.load_all()
     logger.debug("get_context_display: loaded %d context files", len(context_files))
 
-    conflicted_context_files = [
-        {
-            "id": _context_file_identifier(file),
-            "name": _context_file_identifier(file),
-            "label": _context_file_name(file),
-            "reason": getattr(file, "blocked_reason", None) or "Blocked context file",
-        }
-        for file in context_files.values()
-        if getattr(file, "is_blocked", lambda: False)()
-    ]
-    if conflicted_context_files:
-        logger.debug("get_context_display: found %d conflicted context files", len(conflicted_context_files))
-
-    blocked_context_files = [file["label"] for file in conflicted_context_files]
-    warnings: list[str] = []
-    if disabled_sections:
-        warnings.append(f"Disabled sections: {', '.join(disabled_sections)}")
+    context_status = _build_context_status(context_files, disabled_sections)
+    blocked_context_files = list(context_status.blocked_context_files)
+    conflicted_context_files = [item.to_payload() for item in context_status.conflicted_context_files]
+    warnings = list(context_status.warnings)
 
     system_sections = []
     total_system_tokens = 0

--- a/src/alfred/context_display.py
+++ b/src/alfred/context_display.py
@@ -141,6 +141,47 @@ def _serialize_update_event_summary(event: Any) -> dict[str, Any]:
     }
 
 
+def _serialize_value_ledger_entry_summary(entry: Any) -> dict[str, Any]:
+    """Serialize one v2 support value ledger entry summary for /context display."""
+    updated_at = getattr(entry, "updated_at", None)
+    return {
+        "value_id": str(getattr(entry, "value_id", "")),
+        "registry": str(getattr(entry, "registry", "unknown")),
+        "dimension": str(getattr(entry, "dimension", "unknown")),
+        "scope": _serialize_support_scope(getattr(entry, "scope", None)),
+        "value": str(getattr(entry, "value", "")),
+        "status": str(getattr(entry, "status", "unknown")),
+        "confidence": float(getattr(entry, "confidence", 0.0)),
+        "evidence_count": int(getattr(entry, "evidence_count", 0)),
+        "contradiction_count": int(getattr(entry, "contradiction_count", 0)),
+        "last_case_id": getattr(entry, "last_case_id", None),
+        "updated_at": updated_at.isoformat() if updated_at is not None else None,
+        "why": str(getattr(entry, "why", "")),
+    }
+
+
+def _serialize_ledger_update_event_summary(event: Any) -> dict[str, Any]:
+    """Serialize one v2 support ledger update event summary for /context display."""
+    created_at = getattr(event, "created_at", None)
+    trigger_case_ids = getattr(event, "trigger_case_ids", ())
+    return {
+        "event_id": str(getattr(event, "event_id", "")),
+        "entity_type": str(getattr(event, "entity_type", "unknown")),
+        "entity_id": str(getattr(event, "entity_id", "")),
+        "registry": str(getattr(event, "registry", "unknown")),
+        "dimension_or_kind": str(getattr(event, "dimension_or_kind", "unknown")),
+        "scope": _serialize_support_scope(getattr(event, "scope", None)),
+        "old_status": getattr(event, "old_status", None),
+        "new_status": str(getattr(event, "new_status", "unknown")),
+        "old_value": getattr(event, "old_value", None),
+        "new_value": getattr(event, "new_value", None),
+        "trigger_case_ids": [str(item) for item in trigger_case_ids] if trigger_case_ids else [],
+        "reason": str(getattr(event, "reason", "")),
+        "confidence": float(getattr(event, "confidence", 0.0)),
+        "created_at": created_at.isoformat() if created_at is not None else None,
+    }
+
+
 def _serialize_learning_situation_summary(situation: Any) -> dict[str, Any]:
     """Serialize one recent learning-situation summary for /context display."""
     recorded_at = getattr(situation, "recorded_at", None)
@@ -216,13 +257,37 @@ async def _get_support_state_display(alfred: Alfred) -> dict[str, Any]:
         _serialize_pattern_summary(pattern)
         for pattern in getattr(getattr(snapshot, "learned_state", None), "confirmed_patterns", ())
     ]
-    recent_update_events = [
-        _serialize_update_event_summary(event)
-        for event in getattr(getattr(snapshot, "learned_state", None), "recent_update_events", ())
+    learned_state = getattr(snapshot, "learned_state", None)
+
+    recent_update_events = [_serialize_update_event_summary(event) for event in getattr(learned_state, "recent_update_events", ())]
+
+    value_ledger_entries = [
+        _serialize_value_ledger_entry_summary(entry)
+        for entry in getattr(learned_state, "value_ledger_entries", ())
     ]
+
+    raw_value_ledger_summary = getattr(learned_state, "value_ledger_summary", None)
+    if isinstance(raw_value_ledger_summary, dict):
+        value_ledger_summary = {
+            "total": int(raw_value_ledger_summary.get("total", 0)),
+            "counts_by_status": dict(raw_value_ledger_summary.get("counts_by_status", {})),
+            "counts_by_registry": dict(raw_value_ledger_summary.get("counts_by_registry", {})),
+        }
+    else:
+        value_ledger_summary = {
+            "total": 0,
+            "counts_by_status": {},
+            "counts_by_registry": {},
+        }
+
+    recent_ledger_update_events = [
+        _serialize_ledger_update_event_summary(event)
+        for event in getattr(learned_state, "recent_ledger_update_events", ())
+    ]
+
     recent_interventions = [
         _serialize_learning_situation_summary(situation)
-        for situation in getattr(getattr(snapshot, "learned_state", None), "recent_interventions", ())
+        for situation in getattr(learned_state, "recent_interventions", ())
     ]
     active_domains = [_serialize_active_domain(domain) for domain in getattr(snapshot, "active_domains", ())]
     active_arcs = [_serialize_active_arc(arc) for arc in getattr(snapshot, "active_arcs", ())]
@@ -262,6 +327,9 @@ async def _get_support_state_display(alfred: Alfred) -> dict[str, Any]:
             "candidate_patterns": candidate_patterns,
             "confirmed_patterns": confirmed_patterns,
             "recent_update_events": recent_update_events,
+            "value_ledger_entries": value_ledger_entries,
+            "value_ledger_summary": value_ledger_summary,
+            "recent_ledger_update_events": recent_ledger_update_events,
             "recent_interventions": recent_interventions,
         },
         "active_domains": active_domains,

--- a/src/alfred/context_display.py
+++ b/src/alfred/context_display.py
@@ -246,25 +246,19 @@ async def _get_support_state_display(alfred: Alfred) -> dict[str, Any]:
     }
 
     active_patterns = [
-        _serialize_pattern_summary(pattern)
-        for pattern in getattr(getattr(snapshot, "active_runtime_state", None), "active_patterns", ())
+        _serialize_pattern_summary(pattern) for pattern in getattr(getattr(snapshot, "active_runtime_state", None), "active_patterns", ())
     ]
     candidate_patterns = [
-        _serialize_pattern_summary(pattern)
-        for pattern in getattr(getattr(snapshot, "learned_state", None), "candidate_patterns", ())
+        _serialize_pattern_summary(pattern) for pattern in getattr(getattr(snapshot, "learned_state", None), "candidate_patterns", ())
     ]
     confirmed_patterns = [
-        _serialize_pattern_summary(pattern)
-        for pattern in getattr(getattr(snapshot, "learned_state", None), "confirmed_patterns", ())
+        _serialize_pattern_summary(pattern) for pattern in getattr(getattr(snapshot, "learned_state", None), "confirmed_patterns", ())
     ]
     learned_state = getattr(snapshot, "learned_state", None)
 
     recent_update_events = [_serialize_update_event_summary(event) for event in getattr(learned_state, "recent_update_events", ())]
 
-    value_ledger_entries = [
-        _serialize_value_ledger_entry_summary(entry)
-        for entry in getattr(learned_state, "value_ledger_entries", ())
-    ]
+    value_ledger_entries = [_serialize_value_ledger_entry_summary(entry) for entry in getattr(learned_state, "value_ledger_entries", ())]
 
     raw_value_ledger_summary = getattr(learned_state, "value_ledger_summary", None)
     if isinstance(raw_value_ledger_summary, dict):
@@ -281,13 +275,11 @@ async def _get_support_state_display(alfred: Alfred) -> dict[str, Any]:
         }
 
     recent_ledger_update_events = [
-        _serialize_ledger_update_event_summary(event)
-        for event in getattr(learned_state, "recent_ledger_update_events", ())
+        _serialize_ledger_update_event_summary(event) for event in getattr(learned_state, "recent_ledger_update_events", ())
     ]
 
     recent_interventions = [
-        _serialize_learning_situation_summary(situation)
-        for situation in getattr(learned_state, "recent_interventions", ())
+        _serialize_learning_situation_summary(situation) for situation in getattr(learned_state, "recent_interventions", ())
     ]
     active_domains = [_serialize_active_domain(domain) for domain in getattr(snapshot, "active_domains", ())]
     active_arcs = [_serialize_active_arc(arc) for arc in getattr(snapshot, "active_arcs", ())]

--- a/src/alfred/interfaces/webui/protocol.py
+++ b/src/alfred/interfaces/webui/protocol.py
@@ -262,6 +262,23 @@ class DaemonStatusMessage(TypedDict):
     payload: DaemonStatusPayload
 
 
+class ContextConflictPayload(TypedDict):
+    """Structured conflict record for a blocked context file."""
+
+    id: str
+    name: str
+    label: str
+    reason: str
+
+
+class ContextStatusPayload(TypedDict):
+    """Lightweight context-health snapshot used for persistent Web UI warnings."""
+
+    blockedContextFiles: list[str]
+    conflictedContextFiles: list[ContextConflictPayload]
+    warnings: list[str]
+
+
 class StatusUpdatePayload(TypedDict):
     """Payload for status.update message."""
 
@@ -274,6 +291,7 @@ class StatusUpdatePayload(TypedDict):
     reasoningTokens: int
     queueLength: int
     isStreaming: bool
+    contextStatus: NotRequired[ContextStatusPayload | None]
 
 
 class StatusUpdateMessage(TypedDict):

--- a/src/alfred/interfaces/webui/server.py
+++ b/src/alfred/interfaces/webui/server.py
@@ -75,7 +75,7 @@ def _truncate_payload(payload: dict[str, Any], max_chars: int = 200) -> dict[str
     return payload
 
 
-StatusField = str | int | bool | None
+StatusField = str | int | bool | None | dict[str, Any] | list[Any]
 CHUNK_BATCH_FLUSH_INTERVAL_SECONDS = 0.01  # 10ms for low-latency streaming
 CHUNK_BATCH_MAX_CHARS = 1024  # Larger batches to reduce overhead
 
@@ -891,6 +891,14 @@ async def _send_status_update(
                 "reasoningTokens": _coerce_int(getattr(usage, "reasoning_tokens", 0)),
             }
         )
+
+        try:
+            from alfred.context_display import get_context_status
+
+            context_status = await get_context_status(cast(Any, alfred_instance))
+            status["contextStatus"] = context_status.to_websocket_payload()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Failed to build context status payload: %s", exc)
 
     if extra_status:
         status.update(extra_status)

--- a/src/alfred/interfaces/webui/static/css/base.css
+++ b/src/alfred/interfaces/webui/static/css/base.css
@@ -47,6 +47,50 @@ body {
     flex-shrink: 0;
 }
 
+.context-warning-banner {
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid rgba(255, 196, 0, 0.24);
+    background: linear-gradient(180deg, rgba(84, 56, 10, 0.98), rgba(58, 39, 7, 0.98));
+    color: #ffe7a8;
+    flex-shrink: 0;
+}
+
+.context-warning-banner__content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.context-warning-banner__title {
+    font-size: var(--text-sm);
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+}
+
+.context-warning-banner__summary,
+.context-warning-banner__reason,
+.context-warning-banner__file {
+    font-size: var(--text-sm);
+}
+
+.context-warning-banner__file {
+    font-weight: 700;
+}
+
+.context-warning-banner__list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    list-style: none;
+}
+
+.context-warning-banner__item {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
 .header-brand {
     display: flex;
     align-items: center;

--- a/src/alfred/interfaces/webui/static/index.html
+++ b/src/alfred/interfaces/webui/static/index.html
@@ -89,6 +89,8 @@
             </div>
         </header>
 
+        <section id="context-warning-banner" class="context-warning-banner" hidden></section>
+
         <section id="kidcore-homeboard-window" class="kidcore-window" aria-label="Kidcore scrapbook window" data-window-state="collapsed" hidden>
             <div id="kidcore-homeboard-titlebar" class="kidcore-window-titlebar" tabindex="0" aria-label="Kidcore scrapbook window titlebar">
                 <div class="kidcore-window-title-copy">

--- a/src/alfred/interfaces/webui/static/js/components/context-viewer.js
+++ b/src/alfred/interfaces/webui/static/js/components/context-viewer.js
@@ -484,6 +484,62 @@ class ContextViewer extends HTMLElement {
     `;
   }
 
+  _formatValueLedgerSummary(summary) {
+    const total = this._asInt(summary?.total, 0);
+    const counts = summary?.counts_by_status || {};
+    const parts = Object.entries(counts)
+      .filter(([, count]) => this._asInt(count, 0) > 0)
+      .map(([status, count]) => `${status}: ${this._formatNumber(this._asInt(count, 0))}`);
+
+    if (!parts.length) {
+      return `${this._formatNumber(total)} total`;
+    }
+
+    return `${this._formatNumber(total)} total · ${parts.join(" · ")}`;
+  }
+
+  _renderSupportValueLedgerEntryItem(entry) {
+    const registry = this._escapeHtml(entry?.registry || "unknown");
+    const dimension = this._escapeHtml(entry?.dimension || "unknown");
+    const scopeLabel = this._escapeHtml(entry?.scope?.label || "unknown");
+    const value = this._escapeHtml(entry?.value || "");
+    const status = this._escapeHtml(entry?.status || "unknown");
+    const confidence = Number.parseFloat(entry?.confidence || 0).toFixed(2);
+    const evidenceCount = this._formatNumber(this._asInt(entry?.evidence_count, 0));
+    const contradictionCount = this._formatNumber(this._asInt(entry?.contradiction_count, 0));
+    const why = this._escapeHtml(entry?.why || "");
+
+    const label = `${registry}:${dimension} = ${value}`;
+    const meta = `${scopeLabel} · ${status} · conf ${confidence} · ev ${evidenceCount} · contra ${contradictionCount}`;
+
+    return `
+      <div class="support-ledger-entry info-row">
+        <span class="info-value">${this._escapeHtml(label)}</span>
+        <span class="info-label">${this._escapeHtml(meta)}${why ? ` · ${why}` : ""}</span>
+      </div>
+    `;
+  }
+
+  _renderSupportLedgerUpdateEventItem(event) {
+    const entityType = this._escapeHtml(event?.entity_type || "unknown");
+    const registry = this._escapeHtml(event?.registry || "unknown");
+    const dimension = this._escapeHtml(event?.dimension_or_kind || "unknown");
+    const scopeLabel = this._escapeHtml(event?.scope?.label || "unknown");
+    const newStatus = this._escapeHtml(event?.new_status || "unknown");
+    const newValue = this._escapeHtml(event?.new_value || "");
+    const confidence = Number.parseFloat(event?.confidence || 0).toFixed(2);
+
+    const label = `${entityType} ${registry}:${dimension} → ${newValue || newStatus}`;
+    const meta = `${scopeLabel} · ${newStatus} · conf ${confidence}`;
+
+    return `
+      <div class="support-ledger-event info-row">
+        <span class="info-value">${this._escapeHtml(label)}</span>
+        <span class="info-label">${this._escapeHtml(meta)}</span>
+      </div>
+    `;
+  }
+
   _renderSupportArcItem(arc) {
     const title = this._escapeHtml(arc?.title || arc?.arc_id || "Unknown arc");
     const meta = `${arc?.kind || "unknown"} · ${arc?.status || "unknown"}`;
@@ -516,6 +572,9 @@ class ContextViewer extends HTMLElement {
     const candidatePatterns = learnedState.candidate_patterns || [];
     const confirmedPatterns = learnedState.confirmed_patterns || [];
     const recentEvents = learnedState.recent_update_events || [];
+    const valueLedgerEntries = learnedState.value_ledger_entries || [];
+    const valueLedgerSummary = learnedState.value_ledger_summary || {};
+    const recentLedgerEvents = learnedState.recent_ledger_update_events || [];
     const activeArcs = supportState.active_arcs || [];
     const activeDomains = supportState.active_domains || [];
     const effectiveSupportValues = Object.entries(runtimeState.effective_support_values || {});
@@ -683,6 +742,40 @@ class ContextViewer extends HTMLElement {
                   <div class="card-title">Recent Changes</div>
                   <div class="card-content">
                     ${recentEvents.map((event) => this._renderSupportEventItem(event)).join("")}
+                  </div>
+                </div>
+              `
+                  : ""
+              }
+
+              ${
+                valueLedgerEntries.length
+                  ? `
+                <div class="self-model-card">
+                  <div class="card-title">Value Ledger</div>
+                  <div class="card-content">
+                    <div class="info-row">
+                      <span class="info-label">Summary:</span>
+                      <span class="info-value">${this._escapeHtml(this._formatValueLedgerSummary(valueLedgerSummary))}</span>
+                    </div>
+                    ${valueLedgerEntries
+                      .map((entry) => this._renderSupportValueLedgerEntryItem(entry))
+                      .join("")}
+                  </div>
+                </div>
+              `
+                  : ""
+              }
+
+              ${
+                recentLedgerEvents.length
+                  ? `
+                <div class="self-model-card">
+                  <div class="card-title">Ledger Updates</div>
+                  <div class="card-content">
+                    ${recentLedgerEvents
+                      .map((event) => this._renderSupportLedgerUpdateEventItem(event))
+                      .join("")}
                   </div>
                 </div>
               `

--- a/src/alfred/interfaces/webui/static/js/features/context-menu/menu.js
+++ b/src/alfred/interfaces/webui/static/js/features/context-menu/menu.js
@@ -154,6 +154,30 @@ class ContextMenu {
   render() {
     this.container.innerHTML = "";
 
+    if (this.container.dataset.layout === "sheet") {
+      const header = document.createElement("div");
+      header.className = "context-menu-header";
+
+      const title = document.createElement("div");
+      title.className = "context-menu-title";
+      title.textContent = "Actions";
+
+      const closeButton = document.createElement("button");
+      closeButton.type = "button";
+      closeButton.className = "context-menu-close";
+      closeButton.setAttribute("aria-label", "Close context menu");
+      closeButton.textContent = "×";
+      closeButton.addEventListener("click", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        this.close();
+      });
+
+      header.appendChild(title);
+      header.appendChild(closeButton);
+      this.container.appendChild(header);
+    }
+
     this.items.forEach((item, index) => {
       if (item.type === "separator") {
         this.renderSeparator(index);

--- a/src/alfred/interfaces/webui/static/js/features/context-menu/styles.css
+++ b/src/alfred/interfaces/webui/static/js/features/context-menu/styles.css
@@ -62,9 +62,56 @@
   max-width: none;
   max-height: min(68vh, 42rem);
   border-radius: 1rem 1rem 0 0;
+  padding-top: 0;
   overflow-y: auto;
   overscroll-behavior: contain;
   -webkit-overflow-scrolling: touch;
+}
+
+.context-menu[data-layout="sheet"] .context-menu-header {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0.65rem 1rem 0.45rem;
+  background: var(--context-menu-surface-bg);
+  border-bottom: 1px solid var(--context-menu-border);
+}
+
+.context-menu[data-layout="sheet"] .context-menu-title {
+  font-size: var(--text-sm, 0.875rem);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--context-menu-muted);
+}
+
+.context-menu[data-layout="sheet"] .context-menu-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--context-menu-border);
+  background: var(--context-menu-shortcut-bg);
+  color: var(--context-menu-text);
+  font: inherit;
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.context-menu[data-layout="sheet"] .context-menu-close:hover,
+.context-menu[data-layout="sheet"] .context-menu-close:focus {
+  background: var(--context-menu-hover-bg);
+}
+
+.context-menu[data-layout="sheet"] .context-menu-close:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 1px var(--context-menu-border);
 }
 
 @keyframes context-menu-appear {

--- a/src/alfred/interfaces/webui/static/js/main.js
+++ b/src/alfred/interfaces/webui/static/js/main.js
@@ -107,6 +107,7 @@ function initAlfredUI() {
   const chatContainer = document.getElementById("chat-container");
   const queueBadge = document.getElementById("queue-badge");
   const inputArea = document.getElementById("input-area");
+  const contextWarningBanner = document.getElementById("context-warning-banner");
 
   const completionMenu = document.getElementById("completion-menu");
 
@@ -2172,6 +2173,61 @@ function initAlfredUI() {
     }
   }
 
+  function renderContextWarningBanner(contextStatus) {
+    if (!contextWarningBanner) {
+      return;
+    }
+
+    const blocked = Array.isArray(contextStatus?.blockedContextFiles)
+      ? contextStatus.blockedContextFiles
+      : [];
+    const conflicted = Array.isArray(contextStatus?.conflictedContextFiles)
+      ? contextStatus.conflictedContextFiles
+      : [];
+    const warnings = Array.isArray(contextStatus?.warnings) ? contextStatus.warnings : [];
+
+    if (!blocked.length && !conflicted.length && !warnings.length) {
+      contextWarningBanner.hidden = true;
+      contextWarningBanner.innerHTML = "";
+      return;
+    }
+
+    const conflictItems = conflicted
+      .map(
+        (file) => `
+          <li class="context-warning-banner__item">
+            <span class="context-warning-banner__file">${escapeConnectionStatusText(file?.label || file?.name || file?.id || "Unknown")}</span>
+            <span class="context-warning-banner__reason">${escapeConnectionStatusText(file?.reason || "Blocked context file")}</span>
+          </li>
+        `,
+      )
+      .join("");
+    const warningItems = warnings
+      .map(
+        (warning) => `
+          <li class="context-warning-banner__item">
+            <span class="context-warning-banner__reason">${escapeConnectionStatusText(warning)}</span>
+          </li>
+        `,
+      )
+      .join("");
+    const blockedSummary = blocked.length
+      ? `<div class="context-warning-banner__summary">Blocked: ${escapeConnectionStatusText(blocked.join(", "))}</div>`
+      : "";
+
+    contextWarningBanner.hidden = false;
+    contextWarningBanner.innerHTML = `
+      <div class="context-warning-banner__content" role="status" aria-live="polite">
+        <div class="context-warning-banner__title">Context warnings</div>
+        ${blockedSummary}
+        <ul class="context-warning-banner__list">
+          ${conflictItems}
+          ${warningItems}
+        </ul>
+      </div>
+    `;
+  }
+
   // Status Bar Update
   function updateStatusBar(payload) {
     const statusBar = document.getElementById("status-bar");
@@ -2206,6 +2262,10 @@ function initAlfredUI() {
     // Update streaming status
     if (payload.isStreaming !== undefined) {
       statusBar.setAttribute("streaming", payload.isStreaming);
+    }
+
+    if (payload.contextStatus !== undefined) {
+      renderContextWarningBanner(payload.contextStatus);
     }
 
     applyDaemonStatusPayload(payload);

--- a/src/alfred/interfaces/webui/validation.py
+++ b/src/alfred/interfaces/webui/validation.py
@@ -303,6 +303,27 @@ class DaemonStatusMessage(BaseModel):
     model_config = {"extra": "forbid"}
 
 
+class ContextConflictPayload(BaseModel):
+    """Structured conflict record for a blocked context file."""
+
+    id: str = Field(..., min_length=1)
+    name: str = Field(..., min_length=1)
+    label: str = Field(..., min_length=1)
+    reason: str = Field(..., min_length=1)
+
+    model_config = {"extra": "forbid"}
+
+
+class ContextStatusPayload(BaseModel):
+    """Lightweight context-health snapshot used for persistent Web UI warnings."""
+
+    blocked_context_files: list[str] = Field(default_factory=list, alias="blockedContextFiles")
+    conflicted_context_files: list[ContextConflictPayload] = Field(default_factory=list, alias="conflictedContextFiles")
+    warnings: list[str] = Field(default_factory=list)
+
+    model_config = {"populate_by_name": True, "extra": "forbid"}
+
+
 class StatusUpdatePayload(BaseModel):
     """Payload for status.update message."""
 
@@ -315,6 +336,7 @@ class StatusUpdatePayload(BaseModel):
     reasoning_tokens: int = Field(..., alias="reasoningTokens", ge=0)
     queue_length: int = Field(..., alias="queueLength", ge=0)
     is_streaming: bool = Field(..., alias="isStreaming")
+    context_status: ContextStatusPayload | None = Field(default=None, alias="contextStatus")
 
     model_config = {"populate_by_name": True, "extra": "forbid"}
 

--- a/src/alfred/memory/support_learning.py
+++ b/src/alfred/memory/support_learning.py
@@ -499,6 +499,16 @@ class OutcomeObservation:
         )
 
 
+def extract_conversational_outcome_observations(*, attempt: SupportAttempt) -> tuple[OutcomeObservation, ...]:
+    """Stub for Milestone 3B conversational/semantic extraction.
+
+    This is intentionally a no-op placeholder. The repo currently prioritizes deterministic
+    operational observations and case finalization from stored artifacts.
+    """
+    del attempt
+    return ()
+
+
 @dataclass(eq=True)
 class LearningCase:
     """Inspectable case-level synthesis derived from one attempt and its observations."""
@@ -1777,6 +1787,7 @@ __all__ = [
     "SupportTranscriptSpanRef",
     "SupportValueLedgerEntry",
     "apply_bounded_adaptation",
+    "extract_conversational_outcome_observations",
     "derive_bounded_adaptation",
     "derive_learning_case",
     "derive_value_ledger_updates_from_cases",

--- a/src/alfred/memory/support_learning.py
+++ b/src/alfred/memory/support_learning.py
@@ -610,6 +610,146 @@ class LearningCase:
         )
 
 
+_OPERATIONAL_OBSERVATION_SOURCE_TYPES: frozenset[str] = frozenset({"work_state_transition"})
+_OBSERVATION_SCORE_WEIGHTS: dict[str, float] = {
+    "positive": 1.0,
+    "negative": 0.0,
+    "mixed": 0.5,
+    "neutral": 0.25,
+}
+_POSITIVE_EVIDENCE_POLARITIES: frozenset[str] = frozenset({"positive", "mixed"})
+_NEGATIVE_EVIDENCE_POLARITIES: frozenset[str] = frozenset({"negative", "mixed"})
+_SCOPE_PROMOTION_THRESHOLDS: dict[str, int] = {"arc": 2, "context": 4}
+
+
+def _ordered_unique_strings(values: Sequence[str]) -> tuple[str, ...]:
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        ordered.append(value)
+    return tuple(ordered)
+
+
+def _ordered_unique_transcript_refs(values: Sequence[SupportTranscriptSpanRef]) -> tuple[SupportTranscriptSpanRef, ...]:
+    ordered: list[SupportTranscriptSpanRef] = []
+    seen: set[tuple[str, str, str]] = set()
+    for value in values:
+        key = (value.session_id, value.message_start_id, value.message_end_id)
+        if key in seen:
+            continue
+        seen.add(key)
+        ordered.append(value)
+    return tuple(ordered)
+
+
+def _score_outcome_observation(observation: OutcomeObservation) -> float:
+    weight = _OBSERVATION_SCORE_WEIGHTS[observation.signal_polarity]
+    return round(observation.signal_strength * weight, 2)
+
+
+def _average_score(values: Sequence[float]) -> float:
+    if not values:
+        return 0.0
+    return round(sum(values) / len(values), 2)
+
+
+def _derive_learning_case_scope(attempt: SupportAttempt) -> SupportProfileScope:
+    if attempt.active_arc_id is not None:
+        return SupportProfileScope(type="arc", id=attempt.active_arc_id)
+    return SupportProfileScope(type="context", id=attempt.response_mode)
+
+
+def _summarize_learning_case(
+    *,
+    attempt: SupportAttempt,
+    status: LearningCaseStatus,
+    promotion_eligibility: bool,
+) -> str:
+    if status == "insufficient_evidence":
+        return f"Attempt {attempt.attempt_id} finalized with insufficient directional evidence."
+    if promotion_eligibility:
+        return f"Attempt {attempt.attempt_id} produced enough directional evidence to finalize a promotable case."
+    return f"Attempt {attempt.attempt_id} finalized with directional evidence but is not promotion-eligible."
+
+
+def derive_learning_case(
+    *,
+    attempt: SupportAttempt,
+    observations: Sequence[OutcomeObservation],
+) -> LearningCase | None:
+    """Derive one deterministic learning case from a stored attempt bundle."""
+    if not observations:
+        return None
+
+    ordered_observations = tuple(sorted(observations, key=lambda observation: (observation.observed_at, observation.observation_id)))
+    observation_scores = [_score_outcome_observation(observation) for observation in ordered_observations]
+    conversation_scores = [
+        _score_outcome_observation(observation)
+        for observation in ordered_observations
+        if observation.source_type not in _OPERATIONAL_OBSERVATION_SOURCE_TYPES
+    ]
+    operational_scores = [
+        _score_outcome_observation(observation)
+        for observation in ordered_observations
+        if observation.source_type in _OPERATIONAL_OBSERVATION_SOURCE_TYPES
+    ]
+    positive_evidence_count = sum(
+        len(observation.signals)
+        for observation in ordered_observations
+        if observation.signal_polarity in _POSITIVE_EVIDENCE_POLARITIES
+    )
+    negative_evidence_count = sum(
+        len(observation.signals)
+        for observation in ordered_observations
+        if observation.signal_polarity in _NEGATIVE_EVIDENCE_POLARITIES
+    )
+    contradiction_count = sum(1 for observation in ordered_observations if observation.signal_polarity == "mixed")
+    if positive_evidence_count > 0 and negative_evidence_count > 0:
+        contradiction_count += 1
+
+    status: LearningCaseStatus = "complete"
+    if positive_evidence_count == 0 and negative_evidence_count == 0:
+        status = "insufficient_evidence"
+
+    overall_score = _average_score(observation_scores)
+    promotion_eligibility = (
+        status == "complete"
+        and positive_evidence_count > negative_evidence_count
+        and contradiction_count == 0
+        and overall_score >= 0.65
+    )
+
+    return LearningCase(
+        case_id=f"case-{attempt.attempt_id}",
+        attempt_id=attempt.attempt_id,
+        status=status,
+        scope=_derive_learning_case_scope(attempt),
+        created_at=attempt.created_at,
+        finalized_at=ordered_observations[-1].observed_at,
+        aggregate_signals=_ordered_unique_strings(
+            [signal for observation in ordered_observations for signal in observation.signals]
+        ),
+        positive_evidence_count=positive_evidence_count,
+        negative_evidence_count=negative_evidence_count,
+        contradiction_count=contradiction_count,
+        conversation_score=_average_score(conversation_scores),
+        operational_score=_average_score(operational_scores),
+        overall_score=overall_score,
+        promotion_eligibility=promotion_eligibility,
+        evidence_refs=_ordered_unique_transcript_refs(
+            [evidence_ref for observation in ordered_observations for evidence_ref in observation.evidence_refs]
+        ),
+        summary=_summarize_learning_case(
+            attempt=attempt,
+            status=status,
+            promotion_eligibility=promotion_eligibility,
+        ),
+    )
+
+
 @dataclass(eq=True)
 class SupportValueLedgerEntry:
     """V2 ledger row for one scoped support or relational value."""
@@ -883,6 +1023,190 @@ class SupportLedgerUpdateEvent:
             confidence=float(record["confidence"]),
             created_at=_load_datetime(record["created_at"]),
         )
+
+
+@dataclass(eq=True)
+class FinalizedLearningCaseBundle:
+    """One finalized case plus the reply-time attempt that produced it."""
+
+    learning_case: LearningCase
+    attempt: SupportAttempt
+
+    def __post_init__(self) -> None:
+        if self.learning_case.attempt_id != self.attempt.attempt_id:
+            raise ValueError("Finalized learning case bundles must join one case to its source attempt")
+        if self.learning_case.finalized_at is None:
+            raise ValueError("Finalized learning case bundles require finalized cases")
+
+
+@dataclass(eq=True, frozen=True)
+class SupportLedgerDerivationResult:
+    """Deterministic value-ledger writes derived from finalized case bundles."""
+
+    value_entries: tuple[SupportValueLedgerEntry, ...] = ()
+    update_events: tuple[SupportLedgerUpdateEvent, ...] = ()
+
+
+def _value_ledger_key(
+    *,
+    registry: SupportProfileRegistryKind,
+    dimension: str,
+    scope: SupportProfileScope,
+    value: str,
+) -> tuple[SupportProfileRegistryKind, str, SupportProfileScopeType, str, str]:
+    return (registry, dimension, scope.type, scope.id, value)
+
+
+def _iter_attempt_values(attempt: SupportAttempt) -> tuple[tuple[SupportProfileRegistryKind, str, str], ...]:
+    values: list[tuple[SupportProfileRegistryKind, str, str]] = []
+    for dimension, value in attempt.effective_support_values.items():
+        values.append(("support", dimension, value))
+    for dimension, value in attempt.effective_relational_values.items():
+        values.append(("relational", dimension, value))
+    return tuple(values)
+
+
+def _sort_case_bundle(bundle: FinalizedLearningCaseBundle) -> tuple[datetime, str]:
+    finalized_at = bundle.learning_case.finalized_at
+    if finalized_at is None:
+        raise ValueError("Finalized learning case bundles require finalized_at")
+    return (finalized_at, bundle.learning_case.case_id)
+
+
+def _summarize_value_ledger_entry(
+    *,
+    registry: SupportProfileRegistryKind,
+    dimension: str,
+    value: str,
+    scope: SupportProfileScope,
+    supporting_case_count: int,
+    contradiction_count: int,
+) -> str:
+    return (
+        f"{registry} {dimension}={value} has {supporting_case_count} supporting promotable cases and "
+        f"{contradiction_count} conflicting promotable cases in this {scope.type} scope."
+    )
+
+
+def derive_value_ledger_updates_from_cases(
+    *,
+    focus_bundle: FinalizedLearningCaseBundle,
+    scoped_bundles: Sequence[FinalizedLearningCaseBundle],
+    existing_value_entries: Mapping[
+        tuple[SupportProfileRegistryKind, str, SupportProfileScopeType, str, str],
+        SupportValueLedgerEntry,
+    ],
+    now: datetime,
+) -> SupportLedgerDerivationResult:
+    """Derive deterministic value-ledger updates from finalized case bundles in one exact scope."""
+    focus_case = focus_bundle.learning_case
+    if focus_case.status != "complete" or not focus_case.promotion_eligibility:
+        return SupportLedgerDerivationResult()
+
+    scope = focus_case.scope
+    threshold = _SCOPE_PROMOTION_THRESHOLDS.get(scope.type)
+    if threshold is None:
+        return SupportLedgerDerivationResult()
+
+    promotable_bundles = tuple(
+        sorted(
+            (
+                bundle
+                for bundle in scoped_bundles
+                if bundle.learning_case.scope == scope
+                and bundle.learning_case.status == "complete"
+                and bundle.learning_case.promotion_eligibility
+            ),
+            key=_sort_case_bundle,
+        )
+    )
+    if not any(bundle.learning_case.case_id == focus_case.case_id for bundle in promotable_bundles):
+        return SupportLedgerDerivationResult()
+
+    supporting_bundles_by_key: dict[
+        tuple[SupportProfileRegistryKind, str, SupportProfileScopeType, str, str],
+        list[FinalizedLearningCaseBundle],
+    ] = {}
+    for bundle in promotable_bundles:
+        for registry, dimension, value in _iter_attempt_values(bundle.attempt):
+            supporting_bundles_by_key.setdefault(
+                _value_ledger_key(registry=registry, dimension=dimension, scope=scope, value=value),
+                [],
+            ).append(bundle)
+
+    if not supporting_bundles_by_key:
+        return SupportLedgerDerivationResult()
+
+    derived_entries: list[SupportValueLedgerEntry] = []
+    update_events: list[SupportLedgerUpdateEvent] = []
+    for key in sorted(supporting_bundles_by_key):
+        registry, dimension, _, _, value = key
+        supporting_bundles = tuple(supporting_bundles_by_key[key])
+        contradiction_count = sum(
+            len(other_bundles)
+            for other_key, other_bundles in supporting_bundles_by_key.items()
+            if other_key[:4] == key[:4] and other_key[4] != value
+        )
+        confidence = _average_score(
+            [bundle.learning_case.overall_score for bundle in supporting_bundles]
+        )
+        latest_supporting_bundle = supporting_bundles[-1]
+        why = _summarize_value_ledger_entry(
+            registry=registry,
+            dimension=dimension,
+            value=value,
+            scope=scope,
+            supporting_case_count=len(supporting_bundles),
+            contradiction_count=contradiction_count,
+        )
+        status: SupportValueStatus = (
+            "active_auto" if len(supporting_bundles) >= threshold and len(supporting_bundles) > contradiction_count else "shadow"
+        )
+        existing_entry = existing_value_entries.get(key)
+        entry = SupportValueLedgerEntry(
+            value_id=f"value-{registry}-{dimension}-{scope.type}-{scope.id}-{value}",
+            registry=registry,
+            dimension=dimension,
+            scope=scope,
+            value=value,
+            status=status,
+            source="auto_case",
+            confidence=confidence,
+            evidence_count=len(supporting_bundles),
+            contradiction_count=contradiction_count,
+            last_case_id=latest_supporting_bundle.learning_case.case_id,
+            created_at=now if existing_entry is None else existing_entry.created_at,
+            updated_at=now,
+            why=why,
+        )
+        derived_entries.append(entry)
+
+        if existing_entry is None or existing_entry.status != entry.status:
+            update_events.append(
+                SupportLedgerUpdateEvent(
+                    event_id=(
+                        f"event-{entry.value_id}-{entry.status}-{latest_supporting_bundle.learning_case.case_id}"
+                    ),
+                    entity_type="value",
+                    entity_id=entry.value_id,
+                    registry=entry.registry,
+                    dimension_or_kind=entry.dimension,
+                    scope=entry.scope,
+                    old_status=None if existing_entry is None else existing_entry.status,
+                    new_status=entry.status,
+                    old_value=None if existing_entry is None else existing_entry.value,
+                    new_value=entry.value,
+                    trigger_case_ids=tuple(bundle.learning_case.case_id for bundle in supporting_bundles),
+                    reason=entry.why,
+                    confidence=entry.confidence,
+                    created_at=now,
+                )
+            )
+
+    return SupportLedgerDerivationResult(
+        value_entries=tuple(derived_entries),
+        update_events=tuple(sorted(update_events, key=lambda event: (event.entity_id, event.event_id))),
+    )
 
 
 @dataclass(eq=True)
@@ -1439,11 +1763,13 @@ async def apply_bounded_adaptation(
 
 __all__ = [
     "BoundedAdaptationResult",
+    "FinalizedLearningCaseBundle",
     "LearningCase",
     "LearningSituation",
     "OutcomeObservation",
     "SupportAttempt",
     "SupportLearningStore",
+    "SupportLedgerDerivationResult",
     "SupportLedgerUpdateEvent",
     "SupportPattern",
     "SupportPatternLedgerEntry",
@@ -1452,4 +1778,6 @@ __all__ = [
     "SupportValueLedgerEntry",
     "apply_bounded_adaptation",
     "derive_bounded_adaptation",
+    "derive_learning_case",
+    "derive_value_ledger_updates_from_cases",
 ]

--- a/src/alfred/memory/support_learning.py
+++ b/src/alfred/memory/support_learning.py
@@ -61,6 +61,10 @@ ObservationSourceType = Literal[
 ]
 ObservationSignalPolarity = Literal["positive", "negative", "mixed", "neutral"]
 LearningCaseStatus = Literal["open", "complete", "insufficient_evidence", "superseded"]
+SupportValueStatus = Literal["shadow", "active_auto", "confirmed", "rejected", "retired"]
+SupportPatternLedgerStatus = Literal["candidate", "active_auto", "confirmed", "rejected", "retired"]
+SupportLedgerStatus = Literal["shadow", "candidate", "active_auto", "confirmed", "rejected", "retired"]
+SupportLedgerEntityType = Literal["value", "pattern"]
 
 _SUPPORTED_INTERVENTION_FAMILIES: frozenset[str] = frozenset(
     {
@@ -101,6 +105,14 @@ _SUPPORTED_OBSERVATION_SIGNAL_POLARITIES: frozenset[str] = frozenset({"positive"
 _SUPPORTED_LEARNING_CASE_STATUSES: frozenset[str] = frozenset(
     {"open", "complete", "insufficient_evidence", "superseded"}
 )
+_SUPPORTED_VALUE_LEDGER_STATUSES: frozenset[str] = frozenset({"shadow", "active_auto", "confirmed", "rejected", "retired"})
+_SUPPORTED_PATTERN_LEDGER_STATUSES: frozenset[str] = frozenset(
+    {"candidate", "active_auto", "confirmed", "rejected", "retired"}
+)
+_SUPPORTED_LEDGER_STATUSES: frozenset[str] = frozenset(
+    {"shadow", "candidate", "active_auto", "confirmed", "rejected", "retired"}
+)
+_SUPPORTED_LEDGER_ENTITY_TYPES: frozenset[str] = frozenset({"value", "pattern"})
 
 
 def _dump_datetime(value: datetime) -> str:
@@ -190,6 +202,13 @@ def _validate_confidence(value: Any, *, label: str) -> float:
     if not 0.0 <= normalized <= 1.0:
         raise ValueError(f"{label} must be between 0.0 and 1.0")
     return normalized
+
+
+def _validate_registry_kind(value: Any, *, label: str) -> SupportProfileRegistryKind:
+    normalized = _validate_trimmed_string(value, label=label)
+    if normalized not in {"relational", "support"}:
+        raise ValueError(f"{label} must be 'relational' or 'support', got {normalized!r}")
+    return cast(SupportProfileRegistryKind, normalized)
 
 
 def _validate_optional_trimmed_string(value: Any, *, label: str) -> str | None:
@@ -588,6 +607,281 @@ class LearningCase:
             promotion_eligibility=bool(record.get("promotion_eligibility", False)),
             evidence_refs=_load_transcript_span_refs(record.get("evidence_refs")),
             summary=None if summary is None else str(summary),
+        )
+
+
+@dataclass(eq=True)
+class SupportValueLedgerEntry:
+    """V2 ledger row for one scoped support or relational value."""
+
+    value_id: str
+    registry: SupportProfileRegistryKind
+    dimension: str
+    scope: SupportProfileScope
+    value: str
+    status: SupportValueStatus
+    source: str
+    confidence: float
+    evidence_count: int
+    contradiction_count: int
+    last_case_id: str | None
+    created_at: datetime
+    updated_at: datetime
+    why: str
+
+    def __post_init__(self) -> None:
+        self.value_id = _validate_trimmed_string(self.value_id, label="value_id")
+        self.registry = _validate_registry_kind(self.registry, label="registry")
+        self.dimension = _validate_trimmed_string(self.dimension, label="dimension")
+        if not isinstance(self.scope, SupportProfileScope):
+            raise ValueError("scope must be a SupportProfileScope")
+        self.value = _validate_trimmed_string(self.value, label="value")
+        validate_registry_value(self.registry, self.dimension, self.value)
+        self.status = _validate_trimmed_string(self.status, label="status")  # type: ignore[assignment]
+        if self.status not in _SUPPORTED_VALUE_LEDGER_STATUSES:
+            raise ValueError(f"Unsupported support value ledger status: {self.status!r}")
+        self.source = _validate_trimmed_string(self.source, label="source")
+        self.confidence = _validate_confidence(self.confidence, label="confidence")
+        self.evidence_count = _validate_non_negative_int(self.evidence_count, label="evidence_count")
+        self.contradiction_count = _validate_non_negative_int(
+            self.contradiction_count,
+            label="contradiction_count",
+        )
+        self.last_case_id = _validate_optional_trimmed_string(self.last_case_id, label="last_case_id")
+        if not isinstance(self.created_at, datetime):
+            actual_type = type(self.created_at).__name__
+            raise ValueError(f"created_at must be a datetime, got {actual_type}")
+        if not isinstance(self.updated_at, datetime):
+            actual_type = type(self.updated_at).__name__
+            raise ValueError(f"updated_at must be a datetime, got {actual_type}")
+        self.why = _validate_trimmed_string(self.why, label="why")
+
+    def to_record(self) -> dict[str, Any]:
+        return {
+            "value_id": self.value_id,
+            "registry": self.registry,
+            "dimension": self.dimension,
+            "scope_type": self.scope.type,
+            "scope_id": self.scope.id,
+            "value": self.value,
+            "status": self.status,
+            "source": self.source,
+            "confidence": self.confidence,
+            "evidence_count": self.evidence_count,
+            "contradiction_count": self.contradiction_count,
+            "last_case_id": self.last_case_id,
+            "created_at": _dump_datetime(self.created_at),
+            "updated_at": _dump_datetime(self.updated_at),
+            "why": self.why,
+        }
+
+    @classmethod
+    def from_record(cls, record: Mapping[str, Any]) -> SupportValueLedgerEntry:
+        last_case_id = record.get("last_case_id")
+        return cls(
+            value_id=str(record["value_id"]),
+            registry=cast(SupportProfileRegistryKind, str(record["registry"])),
+            dimension=str(record["dimension"]),
+            scope=SupportProfileScope(
+                type=cast(SupportProfileScopeType, str(record["scope_type"])),
+                id=str(record["scope_id"]),
+            ),
+            value=str(record["value"]),
+            status=cast(SupportValueStatus, str(record["status"])),
+            source=str(record["source"]),
+            confidence=float(record["confidence"]),
+            evidence_count=int(record["evidence_count"]),
+            contradiction_count=int(record["contradiction_count"]),
+            last_case_id=None if last_case_id is None else str(last_case_id),
+            created_at=_load_datetime(record["created_at"]),
+            updated_at=_load_datetime(record["updated_at"]),
+            why=str(record["why"]),
+        )
+
+
+@dataclass(eq=True)
+class SupportPatternLedgerEntry:
+    """V2 ledger row for one surfaced pattern with explicit provenance."""
+
+    pattern_id: str
+    registry: SupportProfileRegistryKind
+    kind: PatternKind
+    scope: SupportProfileScope
+    status: SupportPatternLedgerStatus
+    claim: str
+    evidence_count: int
+    contradiction_count: int
+    confidence: float
+    source_case_ids: tuple[str, ...] = ()
+    created_at: datetime = field(default_factory=datetime.now)
+    updated_at: datetime = field(default_factory=datetime.now)
+    why: str = ""
+
+    def __post_init__(self) -> None:
+        self.pattern_id = _validate_trimmed_string(self.pattern_id, label="pattern_id")
+        self.registry = _validate_registry_kind(self.registry, label="registry")
+        self.kind = _validate_trimmed_string(self.kind, label="kind")  # type: ignore[assignment]
+        if self.kind not in _SUPPORTED_PATTERN_KINDS:
+            raise ValueError(f"Unsupported support pattern ledger kind: {self.kind!r}")
+        if not isinstance(self.scope, SupportProfileScope):
+            raise ValueError("scope must be a SupportProfileScope")
+        self.status = _validate_trimmed_string(self.status, label="status")  # type: ignore[assignment]
+        if self.status not in _SUPPORTED_PATTERN_LEDGER_STATUSES:
+            raise ValueError(f"Unsupported support pattern ledger status: {self.status!r}")
+        self.claim = _validate_trimmed_string(self.claim, label="claim")
+        self.evidence_count = _validate_non_negative_int(self.evidence_count, label="evidence_count")
+        self.contradiction_count = _validate_non_negative_int(
+            self.contradiction_count,
+            label="contradiction_count",
+        )
+        self.confidence = _validate_confidence(self.confidence, label="confidence")
+        self.source_case_ids = _validate_string_tuple(self.source_case_ids, label="source_case_ids")
+        if not isinstance(self.created_at, datetime):
+            actual_type = type(self.created_at).__name__
+            raise ValueError(f"created_at must be a datetime, got {actual_type}")
+        if not isinstance(self.updated_at, datetime):
+            actual_type = type(self.updated_at).__name__
+            raise ValueError(f"updated_at must be a datetime, got {actual_type}")
+        self.why = _validate_trimmed_string(self.why, label="why")
+
+    def to_record(self) -> dict[str, Any]:
+        return {
+            "pattern_id": self.pattern_id,
+            "registry": self.registry,
+            "kind": self.kind,
+            "scope_type": self.scope.type,
+            "scope_id": self.scope.id,
+            "status": self.status,
+            "claim": self.claim,
+            "evidence_count": self.evidence_count,
+            "contradiction_count": self.contradiction_count,
+            "confidence": self.confidence,
+            "source_case_ids": _dump_str_tuple(self.source_case_ids),
+            "created_at": _dump_datetime(self.created_at),
+            "updated_at": _dump_datetime(self.updated_at),
+            "why": self.why,
+        }
+
+    @classmethod
+    def from_record(cls, record: Mapping[str, Any]) -> SupportPatternLedgerEntry:
+        return cls(
+            pattern_id=str(record["pattern_id"]),
+            registry=cast(SupportProfileRegistryKind, str(record["registry"])),
+            kind=cast(PatternKind, str(record["kind"])),
+            scope=SupportProfileScope(
+                type=cast(SupportProfileScopeType, str(record["scope_type"])),
+                id=str(record["scope_id"]),
+            ),
+            status=cast(SupportPatternLedgerStatus, str(record["status"])),
+            claim=str(record["claim"]),
+            evidence_count=int(record["evidence_count"]),
+            contradiction_count=int(record["contradiction_count"]),
+            confidence=float(record["confidence"]),
+            source_case_ids=_load_str_tuple(record.get("source_case_ids")),
+            created_at=_load_datetime(record["created_at"]),
+            updated_at=_load_datetime(record["updated_at"]),
+            why=str(record["why"]),
+        )
+
+
+@dataclass(eq=True)
+class SupportLedgerUpdateEvent:
+    """V2 ledger event explaining why one value or pattern changed state."""
+
+    event_id: str
+    entity_type: SupportLedgerEntityType
+    entity_id: str
+    registry: SupportProfileRegistryKind
+    dimension_or_kind: str
+    scope: SupportProfileScope
+    old_status: SupportLedgerStatus | None
+    new_status: SupportLedgerStatus
+    old_value: str | None = None
+    new_value: str | None = None
+    trigger_case_ids: tuple[str, ...] = ()
+    reason: str = ""
+    confidence: float = 0.0
+    created_at: datetime = field(default_factory=datetime.now)
+
+    def __post_init__(self) -> None:
+        self.event_id = _validate_trimmed_string(self.event_id, label="event_id")
+        self.entity_type = _validate_trimmed_string(self.entity_type, label="entity_type")  # type: ignore[assignment]
+        if self.entity_type not in _SUPPORTED_LEDGER_ENTITY_TYPES:
+            raise ValueError(f"Unsupported support ledger entity_type: {self.entity_type!r}")
+        self.entity_id = _validate_trimmed_string(self.entity_id, label="entity_id")
+        self.registry = _validate_registry_kind(self.registry, label="registry")
+        self.dimension_or_kind = _validate_trimmed_string(self.dimension_or_kind, label="dimension_or_kind")
+        if not isinstance(self.scope, SupportProfileScope):
+            raise ValueError("scope must be a SupportProfileScope")
+        if self.old_status is not None:
+            normalized_old_status = _validate_trimmed_string(self.old_status, label="old_status")
+            if normalized_old_status not in _SUPPORTED_LEDGER_STATUSES:
+                raise ValueError(f"Unsupported support ledger old_status: {normalized_old_status!r}")
+            self.old_status = cast(SupportLedgerStatus, normalized_old_status)
+        self.new_status = _validate_trimmed_string(self.new_status, label="new_status")  # type: ignore[assignment]
+        if self.new_status not in _SUPPORTED_LEDGER_STATUSES:
+            raise ValueError(f"Unsupported support ledger new_status: {self.new_status!r}")
+        self.old_value = _validate_optional_trimmed_string(self.old_value, label="old_value")
+        self.new_value = _validate_optional_trimmed_string(self.new_value, label="new_value")
+        self.trigger_case_ids = _validate_string_tuple(self.trigger_case_ids, label="trigger_case_ids")
+        self.reason = _validate_trimmed_string(self.reason, label="reason")
+        self.confidence = _validate_confidence(self.confidence, label="confidence")
+        if not isinstance(self.created_at, datetime):
+            actual_type = type(self.created_at).__name__
+            raise ValueError(f"created_at must be a datetime, got {actual_type}")
+
+        if self.entity_type == "value":
+            if self.new_value is None:
+                raise ValueError("Value ledger update events must set new_value")
+            if self.old_value is not None:
+                validate_registry_value(self.registry, self.dimension_or_kind, self.old_value)
+            validate_registry_value(self.registry, self.dimension_or_kind, self.new_value)
+        else:
+            if self.dimension_or_kind not in _SUPPORTED_PATTERN_KINDS:
+                raise ValueError(f"Unsupported support ledger pattern kind: {self.dimension_or_kind!r}")
+
+    def to_record(self) -> dict[str, Any]:
+        return {
+            "event_id": self.event_id,
+            "entity_type": self.entity_type,
+            "entity_id": self.entity_id,
+            "registry": self.registry,
+            "dimension_or_kind": self.dimension_or_kind,
+            "scope_type": self.scope.type,
+            "scope_id": self.scope.id,
+            "old_status": self.old_status,
+            "new_status": self.new_status,
+            "old_value": self.old_value,
+            "new_value": self.new_value,
+            "trigger_case_ids": _dump_str_tuple(self.trigger_case_ids),
+            "reason": self.reason,
+            "confidence": self.confidence,
+            "created_at": _dump_datetime(self.created_at),
+        }
+
+    @classmethod
+    def from_record(cls, record: Mapping[str, Any]) -> SupportLedgerUpdateEvent:
+        old_status = record.get("old_status")
+        old_value = record.get("old_value")
+        new_value = record.get("new_value")
+        return cls(
+            event_id=str(record["event_id"]),
+            entity_type=cast(SupportLedgerEntityType, str(record["entity_type"])),
+            entity_id=str(record["entity_id"]),
+            registry=cast(SupportProfileRegistryKind, str(record["registry"])),
+            dimension_or_kind=str(record["dimension_or_kind"]),
+            scope=SupportProfileScope(
+                type=cast(SupportProfileScopeType, str(record["scope_type"])),
+                id=str(record["scope_id"]),
+            ),
+            old_status=None if old_status is None else cast(SupportLedgerStatus, str(old_status)),
+            new_status=cast(SupportLedgerStatus, str(record["new_status"])),
+            old_value=None if old_value is None else str(old_value),
+            new_value=None if new_value is None else str(new_value),
+            trigger_case_ids=_load_str_tuple(record.get("trigger_case_ids")),
+            reason=str(record["reason"]),
+            confidence=float(record["confidence"]),
+            created_at=_load_datetime(record["created_at"]),
         )
 
 
@@ -1150,9 +1444,12 @@ __all__ = [
     "OutcomeObservation",
     "SupportAttempt",
     "SupportLearningStore",
+    "SupportLedgerUpdateEvent",
     "SupportPattern",
+    "SupportPatternLedgerEntry",
     "SupportProfileUpdateEvent",
     "SupportTranscriptSpanRef",
+    "SupportValueLedgerEntry",
     "apply_bounded_adaptation",
     "derive_bounded_adaptation",
 ]

--- a/src/alfred/memory/support_learning.py
+++ b/src/alfred/memory/support_learning.py
@@ -51,6 +51,16 @@ PatternKind = Literal[
 ]
 PatternStatus = Literal["candidate", "confirmed", "rejected"]
 UpdateEventStatus = Literal["proposed", "applied", "reverted"]
+ObservationSourceType = Literal[
+    "next_user_turn",
+    "work_state_transition",
+    "explicit_feedback",
+    "timeout",
+    "manual_review",
+    "system_inference",
+]
+ObservationSignalPolarity = Literal["positive", "negative", "mixed", "neutral"]
+LearningCaseStatus = Literal["open", "complete", "insufficient_evidence", "superseded"]
 
 _SUPPORTED_INTERVENTION_FAMILIES: frozenset[str] = frozenset(
     {
@@ -77,6 +87,20 @@ _SUPPORTED_PATTERN_KINDS: frozenset[str] = frozenset(
 )
 _SUPPORTED_PATTERN_STATUSES: frozenset[str] = frozenset({"candidate", "confirmed", "rejected"})
 _SUPPORTED_UPDATE_EVENT_STATUSES: frozenset[str] = frozenset({"proposed", "applied", "reverted"})
+_SUPPORTED_OBSERVATION_SOURCE_TYPES: frozenset[str] = frozenset(
+    {
+        "next_user_turn",
+        "work_state_transition",
+        "explicit_feedback",
+        "timeout",
+        "manual_review",
+        "system_inference",
+    }
+)
+_SUPPORTED_OBSERVATION_SIGNAL_POLARITIES: frozenset[str] = frozenset({"positive", "negative", "mixed", "neutral"})
+_SUPPORTED_LEARNING_CASE_STATUSES: frozenset[str] = frozenset(
+    {"open", "complete", "insufficient_evidence", "superseded"}
+)
 
 
 def _dump_datetime(value: datetime) -> str:
@@ -168,6 +192,63 @@ def _validate_confidence(value: Any, *, label: str) -> float:
     return normalized
 
 
+def _validate_optional_trimmed_string(value: Any, *, label: str) -> str | None:
+    if value is None:
+        return None
+    return _validate_trimmed_string(value, label=label)
+
+
+def _validate_non_negative_int(value: Any, *, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        actual_type = type(value).__name__
+        raise ValueError(f"{label} must be an integer, got {actual_type}")
+    normalized = int(value)
+    if normalized < 0:
+        raise ValueError(f"{label} must be non-negative")
+    return normalized
+
+
+def _validate_bool(value: Any, *, label: str) -> bool:
+    if not isinstance(value, bool):
+        actual_type = type(value).__name__
+        raise ValueError(f"{label} must be a bool, got {actual_type}")
+    return value
+
+
+def _dump_transcript_span_refs(values: tuple[SupportTranscriptSpanRef, ...]) -> str:
+    return json.dumps([value.to_record() for value in values])
+
+
+def _load_transcript_span_refs(value: Any) -> tuple[SupportTranscriptSpanRef, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        decoded: Any = json.loads(value)
+    else:
+        decoded = value
+    if decoded is None:
+        return ()
+    if not isinstance(decoded, list):
+        raise ValueError("Transcript span refs must deserialize to a list of records")
+
+    refs: list[SupportTranscriptSpanRef] = []
+    for decoded_ref in decoded:
+        if not isinstance(decoded_ref, Mapping):
+            raise ValueError("Transcript span refs must contain mapping records")
+        refs.append(SupportTranscriptSpanRef.from_record(decoded_ref))
+    return tuple(refs)
+
+
+def _validate_transcript_span_refs(value: Any, *, label: str) -> tuple[SupportTranscriptSpanRef, ...]:
+    if not isinstance(value, tuple):
+        actual_type = type(value).__name__
+        raise ValueError(f"{label} must be a tuple of SupportTranscriptSpanRef values, got {actual_type}")
+    for evidence_ref in value:
+        if not isinstance(evidence_ref, SupportTranscriptSpanRef):
+            raise ValueError(f"{label} must contain SupportTranscriptSpanRef values")
+    return value
+
+
 @dataclass(eq=True, frozen=True)
 class SupportTranscriptSpanRef:
     """General same-session transcript span used by learning records."""
@@ -202,6 +283,311 @@ class SupportTranscriptSpanRef:
             session_id=str(record["session_id"]),
             message_start_id=str(record["message_start_id"]),
             message_end_id=str(record["message_end_id"]),
+        )
+
+
+@dataclass(eq=True)
+class SupportAttempt:
+    """Reply-time record of what Alfred tried for one support turn."""
+
+    attempt_id: str
+    session_id: str
+    user_message_id: str
+    assistant_message_id: str
+    created_at: datetime
+    need: Need
+    response_mode: str
+    subject_refs: tuple[str, ...] = ()
+    active_arc_id: str | None = None
+    active_domain_ids: tuple[str, ...] = ()
+    effective_support_values: dict[str, str] = field(default_factory=dict)
+    effective_relational_values: dict[str, str] = field(default_factory=dict)
+    intervention_family: InterventionFamily = "confirm"
+    intervention_refs: tuple[str, ...] = ()
+    prompt_contract_summary: str = ""
+    operational_snapshot_ref: str | None = None
+
+    def __post_init__(self) -> None:
+        self.attempt_id = _validate_trimmed_string(self.attempt_id, label="attempt_id")
+        self.session_id = _validate_trimmed_string(self.session_id, label="session_id")
+        self.user_message_id = _validate_trimmed_string(self.user_message_id, label="user_message_id")
+        self.assistant_message_id = _validate_trimmed_string(
+            self.assistant_message_id,
+            label="assistant_message_id",
+        )
+        if not isinstance(self.created_at, datetime):
+            actual_type = type(self.created_at).__name__
+            raise ValueError(f"created_at must be a datetime, got {actual_type}")
+
+        self.need = _validate_trimmed_string(self.need, label="need")  # type: ignore[assignment]
+        if self.need not in _SUPPORTED_NEEDS:
+            raise ValueError(f"Unsupported support attempt need: {self.need!r}")
+
+        self.response_mode = _validate_trimmed_string(self.response_mode, label="response_mode")
+        if self.response_mode not in V1_INTERACTION_CONTEXT_IDS:
+            allowed_contexts = ", ".join(V1_INTERACTION_CONTEXT_IDS)
+            raise ValueError(
+                f"Unsupported support attempt response_mode: {self.response_mode!r}. Expected one of: {allowed_contexts}",
+            )
+
+        self.subject_refs = _validate_string_tuple(self.subject_refs, label="subject_refs")
+        self.active_domain_ids = _validate_string_tuple(self.active_domain_ids, label="active_domain_ids")
+        self.active_arc_id = _validate_optional_trimmed_string(self.active_arc_id, label="active_arc_id")
+        self.intervention_family = _validate_trimmed_string(
+            self.intervention_family,
+            label="intervention_family",
+        )  # type: ignore[assignment]
+        if self.intervention_family not in _SUPPORTED_INTERVENTION_FAMILIES:
+            raise ValueError(f"Unsupported support attempt intervention_family: {self.intervention_family!r}")
+        self.intervention_refs = _validate_string_tuple(self.intervention_refs, label="intervention_refs")
+        self.prompt_contract_summary = _validate_trimmed_string(
+            self.prompt_contract_summary,
+            label="prompt_contract_summary",
+        )
+        self.operational_snapshot_ref = _validate_optional_trimmed_string(
+            self.operational_snapshot_ref,
+            label="operational_snapshot_ref",
+        )
+        self.effective_support_values = _validate_applied_values(
+            self.effective_support_values,
+            registry="support",
+            label="effective_support_values",
+        )
+        self.effective_relational_values = _validate_applied_values(
+            self.effective_relational_values,
+            registry="relational",
+            label="effective_relational_values",
+        )
+
+    def to_record(self) -> dict[str, Any]:
+        return {
+            "attempt_id": self.attempt_id,
+            "session_id": self.session_id,
+            "user_message_id": self.user_message_id,
+            "assistant_message_id": self.assistant_message_id,
+            "created_at": _dump_datetime(self.created_at),
+            "need": self.need,
+            "response_mode": self.response_mode,
+            "subject_refs": _dump_str_tuple(self.subject_refs),
+            "active_arc_id": self.active_arc_id,
+            "active_domain_ids": _dump_str_tuple(self.active_domain_ids),
+            "effective_support_values": json.dumps(self.effective_support_values),
+            "effective_relational_values": json.dumps(self.effective_relational_values),
+            "intervention_family": self.intervention_family,
+            "intervention_refs": _dump_str_tuple(self.intervention_refs),
+            "prompt_contract_summary": self.prompt_contract_summary,
+            "operational_snapshot_ref": self.operational_snapshot_ref,
+        }
+
+    @classmethod
+    def from_record(cls, record: Mapping[str, Any]) -> SupportAttempt:
+        support_values_raw = record.get("effective_support_values")
+        relational_values_raw = record.get("effective_relational_values")
+        support_values = json.loads(support_values_raw) if isinstance(support_values_raw, str) else support_values_raw
+        relational_values = json.loads(relational_values_raw) if isinstance(relational_values_raw, str) else relational_values_raw
+        active_arc_id = record.get("active_arc_id")
+        operational_snapshot_ref = record.get("operational_snapshot_ref")
+        return cls(
+            attempt_id=str(record["attempt_id"]),
+            session_id=str(record["session_id"]),
+            user_message_id=str(record["user_message_id"]),
+            assistant_message_id=str(record["assistant_message_id"]),
+            created_at=_load_datetime(record["created_at"]),
+            need=cast(Need, str(record["need"])),
+            response_mode=str(record["response_mode"]),
+            subject_refs=_load_str_tuple(record.get("subject_refs")),
+            active_arc_id=None if active_arc_id is None else str(active_arc_id),
+            active_domain_ids=_load_str_tuple(record.get("active_domain_ids")),
+            effective_support_values=support_values or {},
+            effective_relational_values=relational_values or {},
+            intervention_family=cast(InterventionFamily, str(record["intervention_family"])),
+            intervention_refs=_load_str_tuple(record.get("intervention_refs")),
+            prompt_contract_summary=str(record["prompt_contract_summary"]),
+            operational_snapshot_ref=None if operational_snapshot_ref is None else str(operational_snapshot_ref),
+        )
+
+
+@dataclass(eq=True)
+class OutcomeObservation:
+    """One post-reply observation linked to a support attempt."""
+
+    observation_id: str
+    attempt_id: str
+    observed_at: datetime
+    source_type: ObservationSourceType
+    signals: tuple[str, ...]
+    signal_polarity: ObservationSignalPolarity
+    signal_strength: float
+    evidence_refs: tuple[SupportTranscriptSpanRef, ...] = ()
+    operational_delta_refs: tuple[str, ...] = ()
+    notes: str | None = None
+
+    def __post_init__(self) -> None:
+        self.observation_id = _validate_trimmed_string(self.observation_id, label="observation_id")
+        self.attempt_id = _validate_trimmed_string(self.attempt_id, label="attempt_id")
+        if not isinstance(self.observed_at, datetime):
+            actual_type = type(self.observed_at).__name__
+            raise ValueError(f"observed_at must be a datetime, got {actual_type}")
+
+        self.source_type = _validate_trimmed_string(self.source_type, label="source_type")  # type: ignore[assignment]
+        if self.source_type not in _SUPPORTED_OBSERVATION_SOURCE_TYPES:
+            raise ValueError(f"Unsupported outcome observation source_type: {self.source_type!r}")
+        self.signals = _validate_string_tuple(self.signals, label="signals")
+        if not self.signals:
+            raise ValueError("signals must contain at least one observation signal")
+        self.signal_polarity = _validate_trimmed_string(
+            self.signal_polarity,
+            label="signal_polarity",
+        )  # type: ignore[assignment]
+        if self.signal_polarity not in _SUPPORTED_OBSERVATION_SIGNAL_POLARITIES:
+            raise ValueError(f"Unsupported outcome observation signal_polarity: {self.signal_polarity!r}")
+        self.signal_strength = _validate_confidence(self.signal_strength, label="signal_strength")
+        self.evidence_refs = _validate_transcript_span_refs(self.evidence_refs, label="evidence_refs")
+        self.operational_delta_refs = _validate_string_tuple(
+            self.operational_delta_refs,
+            label="operational_delta_refs",
+        )
+        self.notes = _validate_optional_trimmed_string(self.notes, label="notes")
+
+    def to_record(self) -> dict[str, Any]:
+        return {
+            "observation_id": self.observation_id,
+            "attempt_id": self.attempt_id,
+            "observed_at": _dump_datetime(self.observed_at),
+            "source_type": self.source_type,
+            "signals": _dump_str_tuple(self.signals),
+            "signal_polarity": self.signal_polarity,
+            "signal_strength": self.signal_strength,
+            "evidence_refs": _dump_transcript_span_refs(self.evidence_refs),
+            "operational_delta_refs": _dump_str_tuple(self.operational_delta_refs),
+            "notes": self.notes,
+        }
+
+    @classmethod
+    def from_record(cls, record: Mapping[str, Any]) -> OutcomeObservation:
+        notes = record.get("notes")
+        return cls(
+            observation_id=str(record["observation_id"]),
+            attempt_id=str(record["attempt_id"]),
+            observed_at=_load_datetime(record["observed_at"]),
+            source_type=cast(ObservationSourceType, str(record["source_type"])),
+            signals=_load_str_tuple(record.get("signals")),
+            signal_polarity=cast(ObservationSignalPolarity, str(record["signal_polarity"])),
+            signal_strength=float(record["signal_strength"]),
+            evidence_refs=_load_transcript_span_refs(record.get("evidence_refs")),
+            operational_delta_refs=_load_str_tuple(record.get("operational_delta_refs")),
+            notes=None if notes is None else str(notes),
+        )
+
+
+@dataclass(eq=True)
+class LearningCase:
+    """Inspectable case-level synthesis derived from one attempt and its observations."""
+
+    case_id: str
+    attempt_id: str
+    status: LearningCaseStatus
+    scope: SupportProfileScope
+    created_at: datetime
+    finalized_at: datetime | None = None
+    aggregate_signals: tuple[str, ...] = ()
+    positive_evidence_count: int = 0
+    negative_evidence_count: int = 0
+    contradiction_count: int = 0
+    conversation_score: float = 0.0
+    operational_score: float = 0.0
+    overall_score: float = 0.0
+    promotion_eligibility: bool = False
+    evidence_refs: tuple[SupportTranscriptSpanRef, ...] = ()
+    summary: str | None = None
+
+    def __post_init__(self) -> None:
+        self.case_id = _validate_trimmed_string(self.case_id, label="case_id")
+        self.attempt_id = _validate_trimmed_string(self.attempt_id, label="attempt_id")
+        self.status = _validate_trimmed_string(self.status, label="status")  # type: ignore[assignment]
+        if self.status not in _SUPPORTED_LEARNING_CASE_STATUSES:
+            raise ValueError(f"Unsupported learning case status: {self.status!r}")
+        if not isinstance(self.scope, SupportProfileScope):
+            raise ValueError("scope must be a SupportProfileScope")
+        if not isinstance(self.created_at, datetime):
+            actual_type = type(self.created_at).__name__
+            raise ValueError(f"created_at must be a datetime, got {actual_type}")
+        if self.finalized_at is not None and not isinstance(self.finalized_at, datetime):
+            actual_type = type(self.finalized_at).__name__
+            raise ValueError(f"finalized_at must be a datetime, got {actual_type}")
+        if self.status == "open":
+            if self.finalized_at is not None:
+                raise ValueError("Open learning cases must not set finalized_at")
+        elif self.finalized_at is None:
+            raise ValueError(f"Learning case status {self.status!r} requires finalized_at")
+
+        self.aggregate_signals = _validate_string_tuple(self.aggregate_signals, label="aggregate_signals")
+        self.positive_evidence_count = _validate_non_negative_int(
+            self.positive_evidence_count,
+            label="positive_evidence_count",
+        )
+        self.negative_evidence_count = _validate_non_negative_int(
+            self.negative_evidence_count,
+            label="negative_evidence_count",
+        )
+        self.contradiction_count = _validate_non_negative_int(
+            self.contradiction_count,
+            label="contradiction_count",
+        )
+        self.conversation_score = _validate_confidence(self.conversation_score, label="conversation_score")
+        self.operational_score = _validate_confidence(self.operational_score, label="operational_score")
+        self.overall_score = _validate_confidence(self.overall_score, label="overall_score")
+        self.promotion_eligibility = _validate_bool(self.promotion_eligibility, label="promotion_eligibility")
+        self.evidence_refs = _validate_transcript_span_refs(self.evidence_refs, label="evidence_refs")
+        self.summary = _validate_optional_trimmed_string(self.summary, label="summary")
+        if self.status != "open" and self.summary is None:
+            raise ValueError(f"Learning case status {self.status!r} requires summary")
+
+    def to_record(self) -> dict[str, Any]:
+        return {
+            "case_id": self.case_id,
+            "attempt_id": self.attempt_id,
+            "status": self.status,
+            "scope_type": self.scope.type,
+            "scope_id": self.scope.id,
+            "created_at": _dump_datetime(self.created_at),
+            "finalized_at": None if self.finalized_at is None else _dump_datetime(self.finalized_at),
+            "aggregate_signals": _dump_str_tuple(self.aggregate_signals),
+            "positive_evidence_count": self.positive_evidence_count,
+            "negative_evidence_count": self.negative_evidence_count,
+            "contradiction_count": self.contradiction_count,
+            "conversation_score": self.conversation_score,
+            "operational_score": self.operational_score,
+            "overall_score": self.overall_score,
+            "promotion_eligibility": self.promotion_eligibility,
+            "evidence_refs": _dump_transcript_span_refs(self.evidence_refs),
+            "summary": self.summary,
+        }
+
+    @classmethod
+    def from_record(cls, record: Mapping[str, Any]) -> LearningCase:
+        finalized_at = record.get("finalized_at")
+        summary = record.get("summary")
+        return cls(
+            case_id=str(record["case_id"]),
+            attempt_id=str(record["attempt_id"]),
+            status=cast(LearningCaseStatus, str(record["status"])),
+            scope=SupportProfileScope(
+                type=cast(SupportProfileScopeType, str(record["scope_type"])),
+                id=str(record["scope_id"]),
+            ),
+            created_at=_load_datetime(record["created_at"]),
+            finalized_at=None if finalized_at is None else _load_datetime(finalized_at),
+            aggregate_signals=_load_str_tuple(record.get("aggregate_signals")),
+            positive_evidence_count=int(record.get("positive_evidence_count", 0)),
+            negative_evidence_count=int(record.get("negative_evidence_count", 0)),
+            contradiction_count=int(record.get("contradiction_count", 0)),
+            conversation_score=float(record.get("conversation_score", 0.0)),
+            operational_score=float(record.get("operational_score", 0.0)),
+            overall_score=float(record.get("overall_score", 0.0)),
+            promotion_eligibility=bool(record.get("promotion_eligibility", False)),
+            evidence_refs=_load_transcript_span_refs(record.get("evidence_refs")),
+            summary=None if summary is None else str(summary),
         )
 
 
@@ -759,7 +1145,10 @@ async def apply_bounded_adaptation(
 
 __all__ = [
     "BoundedAdaptationResult",
+    "LearningCase",
     "LearningSituation",
+    "OutcomeObservation",
+    "SupportAttempt",
     "SupportLearningStore",
     "SupportPattern",
     "SupportProfileUpdateEvent",

--- a/src/alfred/memory/support_learning.py
+++ b/src/alfred/memory/support_learning.py
@@ -102,16 +102,10 @@ _SUPPORTED_OBSERVATION_SOURCE_TYPES: frozenset[str] = frozenset(
     }
 )
 _SUPPORTED_OBSERVATION_SIGNAL_POLARITIES: frozenset[str] = frozenset({"positive", "negative", "mixed", "neutral"})
-_SUPPORTED_LEARNING_CASE_STATUSES: frozenset[str] = frozenset(
-    {"open", "complete", "insufficient_evidence", "superseded"}
-)
+_SUPPORTED_LEARNING_CASE_STATUSES: frozenset[str] = frozenset({"open", "complete", "insufficient_evidence", "superseded"})
 _SUPPORTED_VALUE_LEDGER_STATUSES: frozenset[str] = frozenset({"shadow", "active_auto", "confirmed", "rejected", "retired"})
-_SUPPORTED_PATTERN_LEDGER_STATUSES: frozenset[str] = frozenset(
-    {"candidate", "active_auto", "confirmed", "rejected", "retired"}
-)
-_SUPPORTED_LEDGER_STATUSES: frozenset[str] = frozenset(
-    {"shadow", "candidate", "active_auto", "confirmed", "rejected", "retired"}
-)
+_SUPPORTED_PATTERN_LEDGER_STATUSES: frozenset[str] = frozenset({"candidate", "active_auto", "confirmed", "rejected", "retired"})
+_SUPPORTED_LEDGER_STATUSES: frozenset[str] = frozenset({"shadow", "candidate", "active_auto", "confirmed", "rejected", "retired"})
 _SUPPORTED_LEDGER_ENTITY_TYPES: frozenset[str] = frozenset({"value", "pattern"})
 
 
@@ -697,14 +691,10 @@ def derive_learning_case(
         if observation.source_type in _OPERATIONAL_OBSERVATION_SOURCE_TYPES
     ]
     positive_evidence_count = sum(
-        len(observation.signals)
-        for observation in ordered_observations
-        if observation.signal_polarity in _POSITIVE_EVIDENCE_POLARITIES
+        len(observation.signals) for observation in ordered_observations if observation.signal_polarity in _POSITIVE_EVIDENCE_POLARITIES
     )
     negative_evidence_count = sum(
-        len(observation.signals)
-        for observation in ordered_observations
-        if observation.signal_polarity in _NEGATIVE_EVIDENCE_POLARITIES
+        len(observation.signals) for observation in ordered_observations if observation.signal_polarity in _NEGATIVE_EVIDENCE_POLARITIES
     )
     contradiction_count = sum(1 for observation in ordered_observations if observation.signal_polarity == "mixed")
     if positive_evidence_count > 0 and negative_evidence_count > 0:
@@ -716,10 +706,7 @@ def derive_learning_case(
 
     overall_score = _average_score(observation_scores)
     promotion_eligibility = (
-        status == "complete"
-        and positive_evidence_count > negative_evidence_count
-        and contradiction_count == 0
-        and overall_score >= 0.65
+        status == "complete" and positive_evidence_count > negative_evidence_count and contradiction_count == 0 and overall_score >= 0.65
     )
 
     return LearningCase(
@@ -729,9 +716,7 @@ def derive_learning_case(
         scope=_derive_learning_case_scope(attempt),
         created_at=attempt.created_at,
         finalized_at=ordered_observations[-1].observed_at,
-        aggregate_signals=_ordered_unique_strings(
-            [signal for observation in ordered_observations for signal in observation.signals]
-        ),
+        aggregate_signals=_ordered_unique_strings([signal for observation in ordered_observations for signal in observation.signals]),
         positive_evidence_count=positive_evidence_count,
         negative_evidence_count=negative_evidence_count,
         contradiction_count=contradiction_count,
@@ -1147,9 +1132,7 @@ def derive_value_ledger_updates_from_cases(
             for other_key, other_bundles in supporting_bundles_by_key.items()
             if other_key[:4] == key[:4] and other_key[4] != value
         )
-        confidence = _average_score(
-            [bundle.learning_case.overall_score for bundle in supporting_bundles]
-        )
+        confidence = _average_score([bundle.learning_case.overall_score for bundle in supporting_bundles])
         latest_supporting_bundle = supporting_bundles[-1]
         why = _summarize_value_ledger_entry(
             registry=registry,
@@ -1184,9 +1167,7 @@ def derive_value_ledger_updates_from_cases(
         if existing_entry is None or existing_entry.status != entry.status:
             update_events.append(
                 SupportLedgerUpdateEvent(
-                    event_id=(
-                        f"event-{entry.value_id}-{entry.status}-{latest_supporting_bundle.learning_case.case_id}"
-                    ),
+                    event_id=(f"event-{entry.value_id}-{entry.status}-{latest_supporting_bundle.learning_case.case_id}"),
                     entity_type="value",
                     entity_id=entry.value_id,
                     registry=entry.registry,

--- a/src/alfred/memory/support_learning.py
+++ b/src/alfred/memory/support_learning.py
@@ -499,16 +499,6 @@ class OutcomeObservation:
         )
 
 
-def extract_conversational_outcome_observations(*, attempt: SupportAttempt) -> tuple[OutcomeObservation, ...]:
-    """Stub for Milestone 3B conversational/semantic extraction.
-
-    This is intentionally a no-op placeholder. The repo currently prioritizes deterministic
-    operational observations and case finalization from stored artifacts.
-    """
-    del attempt
-    return ()
-
-
 @dataclass(eq=True)
 class LearningCase:
     """Inspectable case-level synthesis derived from one attempt and its observations."""
@@ -1787,7 +1777,6 @@ __all__ = [
     "SupportTranscriptSpanRef",
     "SupportValueLedgerEntry",
     "apply_bounded_adaptation",
-    "extract_conversational_outcome_observations",
     "derive_bounded_adaptation",
     "derive_learning_case",
     "derive_value_ledger_updates_from_cases",

--- a/src/alfred/storage/sqlite.py
+++ b/src/alfred/storage/sqlite.py
@@ -4562,7 +4562,15 @@ class SQLiteStore:
         context_id: str | None = None,
         arc_id: str | None = None,
     ) -> SupportProfileValue | None:
-        """Resolve the most specific stored value by arc, then context, then global scope."""
+        """Resolve the most specific stored value by arc, then context, then global scope.
+
+        This method prefers *active* v2 value-ledger entries (case-derived learning) when
+        available, while falling back to the legacy v1 support-profile values.
+        """
+        await self._init()
+
+        import aiosqlite
+
         scopes_to_try: list[SupportProfileScope] = []
         if arc_id is not None:
             scopes_to_try.append(SupportProfileScope(type="arc", id=arc_id))
@@ -4570,10 +4578,60 @@ class SQLiteStore:
             scopes_to_try.append(SupportProfileScope(type="context", id=context_id))
         scopes_to_try.append(SupportProfileScope(type="global", id="user"))
 
-        for scope in scopes_to_try:
-            resolved = await self.get_support_profile_value(registry, dimension, scope)
-            if resolved is not None:
-                return resolved
+        async with aiosqlite.connect(self.db_path) as db:
+            await self._load_extensions(db)
+            await db.execute("PRAGMA foreign_keys = ON")
+            db.row_factory = aiosqlite.Row
+
+            for scope in scopes_to_try:
+                async with db.execute(
+                    """
+                    SELECT * FROM support_value_ledger_entries
+                    WHERE registry = ?
+                      AND dimension = ?
+                      AND scope_type = ?
+                      AND scope_id = ?
+                      AND status IN ('confirmed', 'active_auto')
+                    ORDER BY
+                      CASE status
+                        WHEN 'confirmed' THEN 0
+                        WHEN 'active_auto' THEN 1
+                        ELSE 2
+                      END,
+                      confidence DESC,
+                      updated_at DESC,
+                      value_id ASC
+                    LIMIT 1
+                    """,
+                    (registry, dimension, scope.type, scope.id),
+                ) as cursor:
+                    row = await cursor.fetchone()
+                    if row is not None:
+                        entry = SupportValueLedgerEntry.from_record(dict(row))
+                        evidence_refs = (entry.last_case_id,) if entry.last_case_id else ()
+                        return SupportProfileValue(
+                            registry=entry.registry,
+                            dimension=entry.dimension,
+                            scope=entry.scope,
+                            value=entry.value,
+                            status="confirmed",
+                            confidence=entry.confidence,
+                            source="auto_adapted",
+                            created_at=entry.created_at,
+                            updated_at=entry.updated_at,
+                            evidence_refs=evidence_refs,
+                        )
+
+                async with db.execute(
+                    """
+                    SELECT * FROM support_profile_values
+                    WHERE registry = ? AND dimension = ? AND scope_type = ? AND scope_id = ?
+                    """,
+                    (registry, dimension, scope.type, scope.id),
+                ) as cursor:
+                    row = await cursor.fetchone()
+                    if row is not None:
+                        return SupportProfileValue.from_record(dict(row))
 
         return None
 

--- a/src/alfred/storage/sqlite.py
+++ b/src/alfred/storage/sqlite.py
@@ -2344,9 +2344,7 @@ class SQLiteStore:
             operational_delta_refs = (*operational_delta_refs, f"{entity_type}:{entity_id}")
 
         observation = OutcomeObservation(
-            observation_id=(
-                f"obs-{attempt.attempt_id}-{signal}-{entity_type}-{entity_id}-{observed_at.isoformat()}"
-            ),
+            observation_id=(f"obs-{attempt.attempt_id}-{signal}-{entity_type}-{entity_id}-{observed_at.isoformat()}"),
             attempt_id=attempt.attempt_id,
             observed_at=observed_at,
             source_type="work_state_transition",
@@ -2360,11 +2358,7 @@ class SQLiteStore:
         await self._upsert_support_outcome_observation(db, observation)
 
         learning_case = await self._finalize_support_learning_case_in_tx(db, attempt.attempt_id)
-        if (
-            learning_case is None
-            or learning_case.status != "complete"
-            or not learning_case.promotion_eligibility
-        ):
+        if learning_case is None or learning_case.status != "complete" or not learning_case.promotion_eligibility:
             return
 
         await self._apply_support_case_learning_in_tx(db, learning_case.case_id)

--- a/src/alfred/storage/sqlite.py
+++ b/src/alfred/storage/sqlite.py
@@ -17,9 +17,15 @@ from time import perf_counter
 from typing import Any
 
 from alfred.memory.support_learning import (
+    LearningCase,
     LearningSituation,
+    OutcomeObservation,
+    SupportAttempt,
+    SupportLedgerUpdateEvent,
     SupportPattern,
+    SupportPatternLedgerEntry,
     SupportProfileUpdateEvent,
+    SupportValueLedgerEntry,
 )
 from alfred.memory.support_memory import (
     ArcBlocker,
@@ -1165,6 +1171,153 @@ class SQLiteStore:
         await db.execute("""
             CREATE INDEX IF NOT EXISTS idx_support_profile_scope
             ON support_profile_values(scope_type, scope_id, registry, dimension)
+        """)
+
+        await db.execute("""
+            CREATE TABLE IF NOT EXISTS support_attempts (
+                attempt_id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                user_message_id TEXT NOT NULL,
+                assistant_message_id TEXT NOT NULL,
+                created_at TIMESTAMP NOT NULL,
+                need TEXT NOT NULL,
+                response_mode TEXT NOT NULL,
+                subject_refs JSON NOT NULL DEFAULT '[]',
+                active_arc_id TEXT,
+                active_domain_ids JSON NOT NULL DEFAULT '[]',
+                effective_support_values JSON NOT NULL DEFAULT '{}',
+                effective_relational_values JSON NOT NULL DEFAULT '{}',
+                intervention_family TEXT NOT NULL,
+                intervention_refs JSON NOT NULL DEFAULT '[]',
+                prompt_contract_summary TEXT NOT NULL,
+                operational_snapshot_ref TEXT,
+                FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE,
+                FOREIGN KEY (session_id, user_message_id) REFERENCES session_messages(session_id, message_id) ON DELETE CASCADE,
+                FOREIGN KEY (session_id, assistant_message_id) REFERENCES session_messages(session_id, message_id) ON DELETE CASCADE
+            )
+        """)
+        await db.execute("""
+            CREATE INDEX IF NOT EXISTS idx_support_attempts_session_created
+            ON support_attempts(session_id, created_at ASC, attempt_id ASC)
+        """)
+
+        await db.execute("""
+            CREATE TABLE IF NOT EXISTS support_outcome_observations (
+                observation_id TEXT PRIMARY KEY,
+                attempt_id TEXT NOT NULL,
+                observed_at TIMESTAMP NOT NULL,
+                source_type TEXT NOT NULL,
+                signals JSON NOT NULL DEFAULT '[]',
+                signal_polarity TEXT NOT NULL,
+                signal_strength REAL NOT NULL,
+                evidence_refs JSON NOT NULL DEFAULT '[]',
+                operational_delta_refs JSON NOT NULL DEFAULT '[]',
+                notes TEXT,
+                FOREIGN KEY (attempt_id) REFERENCES support_attempts(attempt_id) ON DELETE CASCADE
+            )
+        """)
+        await db.execute("""
+            CREATE INDEX IF NOT EXISTS idx_support_outcome_observations_attempt_observed
+            ON support_outcome_observations(attempt_id, observed_at ASC, observation_id ASC)
+        """)
+
+        await db.execute("""
+            CREATE TABLE IF NOT EXISTS support_learning_cases (
+                case_id TEXT PRIMARY KEY,
+                attempt_id TEXT NOT NULL UNIQUE,
+                status TEXT NOT NULL,
+                scope_type TEXT NOT NULL,
+                scope_id TEXT NOT NULL,
+                created_at TIMESTAMP NOT NULL,
+                finalized_at TIMESTAMP,
+                aggregate_signals JSON NOT NULL DEFAULT '[]',
+                positive_evidence_count INTEGER NOT NULL DEFAULT 0,
+                negative_evidence_count INTEGER NOT NULL DEFAULT 0,
+                contradiction_count INTEGER NOT NULL DEFAULT 0,
+                conversation_score REAL NOT NULL,
+                operational_score REAL NOT NULL,
+                overall_score REAL NOT NULL,
+                promotion_eligibility INTEGER NOT NULL DEFAULT 0,
+                evidence_refs JSON NOT NULL DEFAULT '[]',
+                summary TEXT,
+                FOREIGN KEY (attempt_id) REFERENCES support_attempts(attempt_id) ON DELETE CASCADE
+            )
+        """)
+        await db.execute("""
+            CREATE INDEX IF NOT EXISTS idx_support_learning_cases_scope_status
+            ON support_learning_cases(scope_type, scope_id, status, created_at DESC)
+        """)
+
+        await db.execute("""
+            CREATE TABLE IF NOT EXISTS support_value_ledger_entries (
+                value_id TEXT PRIMARY KEY,
+                registry TEXT NOT NULL,
+                dimension TEXT NOT NULL,
+                scope_type TEXT NOT NULL,
+                scope_id TEXT NOT NULL,
+                value TEXT NOT NULL,
+                status TEXT NOT NULL,
+                source TEXT NOT NULL,
+                confidence REAL NOT NULL,
+                evidence_count INTEGER NOT NULL DEFAULT 0,
+                contradiction_count INTEGER NOT NULL DEFAULT 0,
+                last_case_id TEXT,
+                created_at TIMESTAMP NOT NULL,
+                updated_at TIMESTAMP NOT NULL,
+                why TEXT NOT NULL,
+                FOREIGN KEY (last_case_id) REFERENCES support_learning_cases(case_id) ON DELETE SET NULL
+            )
+        """)
+        await db.execute("""
+            CREATE INDEX IF NOT EXISTS idx_support_value_ledger_scope
+            ON support_value_ledger_entries(scope_type, scope_id, registry, dimension)
+        """)
+
+        await db.execute("""
+            CREATE TABLE IF NOT EXISTS support_pattern_ledger_entries (
+                pattern_id TEXT PRIMARY KEY,
+                registry TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                scope_type TEXT NOT NULL,
+                scope_id TEXT NOT NULL,
+                status TEXT NOT NULL,
+                claim TEXT NOT NULL,
+                evidence_count INTEGER NOT NULL DEFAULT 0,
+                contradiction_count INTEGER NOT NULL DEFAULT 0,
+                confidence REAL NOT NULL,
+                source_case_ids JSON NOT NULL DEFAULT '[]',
+                created_at TIMESTAMP NOT NULL,
+                updated_at TIMESTAMP NOT NULL,
+                why TEXT NOT NULL
+            )
+        """)
+        await db.execute("""
+            CREATE INDEX IF NOT EXISTS idx_support_pattern_ledger_scope
+            ON support_pattern_ledger_entries(scope_type, scope_id, registry, kind)
+        """)
+
+        await db.execute("""
+            CREATE TABLE IF NOT EXISTS support_ledger_update_events (
+                event_id TEXT PRIMARY KEY,
+                entity_type TEXT NOT NULL,
+                entity_id TEXT NOT NULL,
+                registry TEXT NOT NULL,
+                dimension_or_kind TEXT NOT NULL,
+                scope_type TEXT NOT NULL,
+                scope_id TEXT NOT NULL,
+                old_status TEXT,
+                new_status TEXT NOT NULL,
+                old_value TEXT,
+                new_value TEXT,
+                trigger_case_ids JSON NOT NULL DEFAULT '[]',
+                reason TEXT NOT NULL,
+                confidence REAL NOT NULL,
+                created_at TIMESTAMP NOT NULL
+            )
+        """)
+        await db.execute("""
+            CREATE INDEX IF NOT EXISTS idx_support_ledger_update_events_entity
+            ON support_ledger_update_events(entity_type, entity_id, created_at ASC)
         """)
 
     # === Session Operations ===
@@ -3244,6 +3397,441 @@ class SQLiteStore:
                 )
             )
         return matches
+
+    async def save_support_attempt(self, attempt: SupportAttempt) -> None:
+        """Save or update one v2 support attempt."""
+        await self._init()
+
+        import aiosqlite
+
+        record = attempt.to_record()
+
+        async with aiosqlite.connect(self.db_path) as db:
+            await self._load_extensions(db)
+            await db.execute("PRAGMA foreign_keys = ON")
+            await db.execute(
+                """
+                INSERT INTO support_attempts (
+                    attempt_id, session_id, user_message_id, assistant_message_id,
+                    created_at, need, response_mode, subject_refs, active_arc_id,
+                    active_domain_ids, effective_support_values,
+                    effective_relational_values, intervention_family,
+                    intervention_refs, prompt_contract_summary,
+                    operational_snapshot_ref
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(attempt_id) DO UPDATE SET
+                    session_id = excluded.session_id,
+                    user_message_id = excluded.user_message_id,
+                    assistant_message_id = excluded.assistant_message_id,
+                    created_at = excluded.created_at,
+                    need = excluded.need,
+                    response_mode = excluded.response_mode,
+                    subject_refs = excluded.subject_refs,
+                    active_arc_id = excluded.active_arc_id,
+                    active_domain_ids = excluded.active_domain_ids,
+                    effective_support_values = excluded.effective_support_values,
+                    effective_relational_values = excluded.effective_relational_values,
+                    intervention_family = excluded.intervention_family,
+                    intervention_refs = excluded.intervention_refs,
+                    prompt_contract_summary = excluded.prompt_contract_summary,
+                    operational_snapshot_ref = excluded.operational_snapshot_ref
+                """,
+                (
+                    record["attempt_id"],
+                    record["session_id"],
+                    record["user_message_id"],
+                    record["assistant_message_id"],
+                    record["created_at"],
+                    record["need"],
+                    record["response_mode"],
+                    record["subject_refs"],
+                    record["active_arc_id"],
+                    record["active_domain_ids"],
+                    record["effective_support_values"],
+                    record["effective_relational_values"],
+                    record["intervention_family"],
+                    record["intervention_refs"],
+                    record["prompt_contract_summary"],
+                    record["operational_snapshot_ref"],
+                ),
+            )
+            await db.commit()
+
+    async def get_support_attempt(self, attempt_id: str) -> SupportAttempt | None:
+        """Load one v2 support attempt by ID."""
+        await self._init()
+
+        import aiosqlite
+
+        async with aiosqlite.connect(self.db_path) as db:
+            await self._load_extensions(db)
+            await db.execute("PRAGMA foreign_keys = ON")
+            db.row_factory = aiosqlite.Row
+            async with db.execute("SELECT * FROM support_attempts WHERE attempt_id = ?", (attempt_id,)) as cursor:
+                row = await cursor.fetchone()
+                if row is None:
+                    return None
+                return SupportAttempt.from_record(dict(row))
+
+    async def save_support_outcome_observation(self, observation: OutcomeObservation) -> None:
+        """Save or update one v2 support outcome observation."""
+        await self._init()
+
+        import aiosqlite
+
+        record = observation.to_record()
+
+        async with aiosqlite.connect(self.db_path) as db:
+            await self._load_extensions(db)
+            await db.execute("PRAGMA foreign_keys = ON")
+            await db.execute(
+                """
+                INSERT INTO support_outcome_observations (
+                    observation_id, attempt_id, observed_at, source_type, signals,
+                    signal_polarity, signal_strength, evidence_refs,
+                    operational_delta_refs, notes
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(observation_id) DO UPDATE SET
+                    attempt_id = excluded.attempt_id,
+                    observed_at = excluded.observed_at,
+                    source_type = excluded.source_type,
+                    signals = excluded.signals,
+                    signal_polarity = excluded.signal_polarity,
+                    signal_strength = excluded.signal_strength,
+                    evidence_refs = excluded.evidence_refs,
+                    operational_delta_refs = excluded.operational_delta_refs,
+                    notes = excluded.notes
+                """,
+                (
+                    record["observation_id"],
+                    record["attempt_id"],
+                    record["observed_at"],
+                    record["source_type"],
+                    record["signals"],
+                    record["signal_polarity"],
+                    record["signal_strength"],
+                    record["evidence_refs"],
+                    record["operational_delta_refs"],
+                    record["notes"],
+                ),
+            )
+            await db.commit()
+
+    async def list_support_outcome_observations(self, attempt_id: str) -> list[OutcomeObservation]:
+        """List v2 support observations for one attempt in chronological order."""
+        await self._init()
+
+        import aiosqlite
+
+        async with aiosqlite.connect(self.db_path) as db:
+            await self._load_extensions(db)
+            await db.execute("PRAGMA foreign_keys = ON")
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                """
+                SELECT * FROM support_outcome_observations
+                WHERE attempt_id = ?
+                ORDER BY observed_at ASC, observation_id ASC
+                """,
+                (attempt_id,),
+            ) as cursor:
+                rows = await cursor.fetchall()
+                return [OutcomeObservation.from_record(dict(row)) for row in rows]
+
+    async def save_support_learning_case(self, learning_case: LearningCase) -> None:
+        """Save or update one v2 support learning case."""
+        await self._init()
+
+        import aiosqlite
+
+        record = learning_case.to_record()
+
+        async with aiosqlite.connect(self.db_path) as db:
+            await self._load_extensions(db)
+            await db.execute("PRAGMA foreign_keys = ON")
+            await db.execute(
+                """
+                INSERT INTO support_learning_cases (
+                    case_id, attempt_id, status, scope_type, scope_id,
+                    created_at, finalized_at, aggregate_signals,
+                    positive_evidence_count, negative_evidence_count,
+                    contradiction_count, conversation_score,
+                    operational_score, overall_score,
+                    promotion_eligibility, evidence_refs, summary
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(case_id) DO UPDATE SET
+                    attempt_id = excluded.attempt_id,
+                    status = excluded.status,
+                    scope_type = excluded.scope_type,
+                    scope_id = excluded.scope_id,
+                    created_at = excluded.created_at,
+                    finalized_at = excluded.finalized_at,
+                    aggregate_signals = excluded.aggregate_signals,
+                    positive_evidence_count = excluded.positive_evidence_count,
+                    negative_evidence_count = excluded.negative_evidence_count,
+                    contradiction_count = excluded.contradiction_count,
+                    conversation_score = excluded.conversation_score,
+                    operational_score = excluded.operational_score,
+                    overall_score = excluded.overall_score,
+                    promotion_eligibility = excluded.promotion_eligibility,
+                    evidence_refs = excluded.evidence_refs,
+                    summary = excluded.summary
+                """,
+                (
+                    record["case_id"],
+                    record["attempt_id"],
+                    record["status"],
+                    record["scope_type"],
+                    record["scope_id"],
+                    record["created_at"],
+                    record["finalized_at"],
+                    record["aggregate_signals"],
+                    record["positive_evidence_count"],
+                    record["negative_evidence_count"],
+                    record["contradiction_count"],
+                    record["conversation_score"],
+                    record["operational_score"],
+                    record["overall_score"],
+                    int(record["promotion_eligibility"]),
+                    record["evidence_refs"],
+                    record["summary"],
+                ),
+            )
+            await db.commit()
+
+    async def get_support_learning_case(self, case_id: str) -> LearningCase | None:
+        """Load one v2 support learning case by ID."""
+        await self._init()
+
+        import aiosqlite
+
+        async with aiosqlite.connect(self.db_path) as db:
+            await self._load_extensions(db)
+            await db.execute("PRAGMA foreign_keys = ON")
+            db.row_factory = aiosqlite.Row
+            async with db.execute("SELECT * FROM support_learning_cases WHERE case_id = ?", (case_id,)) as cursor:
+                row = await cursor.fetchone()
+                if row is None:
+                    return None
+                return LearningCase.from_record(dict(row))
+
+    async def save_support_value_ledger_entry(self, value_entry: SupportValueLedgerEntry) -> None:
+        """Save or update one v2 support value ledger entry."""
+        await self._init()
+
+        import aiosqlite
+
+        record = value_entry.to_record()
+
+        async with aiosqlite.connect(self.db_path) as db:
+            await self._load_extensions(db)
+            await db.execute("PRAGMA foreign_keys = ON")
+            await db.execute(
+                """
+                INSERT INTO support_value_ledger_entries (
+                    value_id, registry, dimension, scope_type, scope_id, value,
+                    status, source, confidence, evidence_count,
+                    contradiction_count, last_case_id, created_at,
+                    updated_at, why
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(value_id) DO UPDATE SET
+                    registry = excluded.registry,
+                    dimension = excluded.dimension,
+                    scope_type = excluded.scope_type,
+                    scope_id = excluded.scope_id,
+                    value = excluded.value,
+                    status = excluded.status,
+                    source = excluded.source,
+                    confidence = excluded.confidence,
+                    evidence_count = excluded.evidence_count,
+                    contradiction_count = excluded.contradiction_count,
+                    last_case_id = excluded.last_case_id,
+                    created_at = excluded.created_at,
+                    updated_at = excluded.updated_at,
+                    why = excluded.why
+                """,
+                (
+                    record["value_id"],
+                    record["registry"],
+                    record["dimension"],
+                    record["scope_type"],
+                    record["scope_id"],
+                    record["value"],
+                    record["status"],
+                    record["source"],
+                    record["confidence"],
+                    record["evidence_count"],
+                    record["contradiction_count"],
+                    record["last_case_id"],
+                    record["created_at"],
+                    record["updated_at"],
+                    record["why"],
+                ),
+            )
+            await db.commit()
+
+    async def list_support_value_ledger_entries(self) -> list[SupportValueLedgerEntry]:
+        """List all v2 support value ledger entries in deterministic order."""
+        await self._init()
+
+        import aiosqlite
+
+        async with aiosqlite.connect(self.db_path) as db:
+            await self._load_extensions(db)
+            await db.execute("PRAGMA foreign_keys = ON")
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                """
+                SELECT * FROM support_value_ledger_entries
+                ORDER BY registry ASC, dimension ASC, scope_type ASC, scope_id ASC, value_id ASC
+                """,
+            ) as cursor:
+                rows = await cursor.fetchall()
+                return [SupportValueLedgerEntry.from_record(dict(row)) for row in rows]
+
+    async def save_support_pattern_ledger_entry(self, pattern_entry: SupportPatternLedgerEntry) -> None:
+        """Save or update one v2 support pattern ledger entry."""
+        await self._init()
+
+        import aiosqlite
+
+        record = pattern_entry.to_record()
+
+        async with aiosqlite.connect(self.db_path) as db:
+            await self._load_extensions(db)
+            await db.execute("PRAGMA foreign_keys = ON")
+            await db.execute(
+                """
+                INSERT INTO support_pattern_ledger_entries (
+                    pattern_id, registry, kind, scope_type, scope_id, status,
+                    claim, evidence_count, contradiction_count, confidence,
+                    source_case_ids, created_at, updated_at, why
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(pattern_id) DO UPDATE SET
+                    registry = excluded.registry,
+                    kind = excluded.kind,
+                    scope_type = excluded.scope_type,
+                    scope_id = excluded.scope_id,
+                    status = excluded.status,
+                    claim = excluded.claim,
+                    evidence_count = excluded.evidence_count,
+                    contradiction_count = excluded.contradiction_count,
+                    confidence = excluded.confidence,
+                    source_case_ids = excluded.source_case_ids,
+                    created_at = excluded.created_at,
+                    updated_at = excluded.updated_at,
+                    why = excluded.why
+                """,
+                (
+                    record["pattern_id"],
+                    record["registry"],
+                    record["kind"],
+                    record["scope_type"],
+                    record["scope_id"],
+                    record["status"],
+                    record["claim"],
+                    record["evidence_count"],
+                    record["contradiction_count"],
+                    record["confidence"],
+                    record["source_case_ids"],
+                    record["created_at"],
+                    record["updated_at"],
+                    record["why"],
+                ),
+            )
+            await db.commit()
+
+    async def get_support_pattern_ledger_entry(self, pattern_id: str) -> SupportPatternLedgerEntry | None:
+        """Load one v2 support pattern ledger entry by ID."""
+        await self._init()
+
+        import aiosqlite
+
+        async with aiosqlite.connect(self.db_path) as db:
+            await self._load_extensions(db)
+            await db.execute("PRAGMA foreign_keys = ON")
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                "SELECT * FROM support_pattern_ledger_entries WHERE pattern_id = ?",
+                (pattern_id,),
+            ) as cursor:
+                row = await cursor.fetchone()
+                if row is None:
+                    return None
+                return SupportPatternLedgerEntry.from_record(dict(row))
+
+    async def save_support_ledger_update_event(self, event: SupportLedgerUpdateEvent) -> None:
+        """Save or update one v2 support ledger update event."""
+        await self._init()
+
+        import aiosqlite
+
+        record = event.to_record()
+
+        async with aiosqlite.connect(self.db_path) as db:
+            await self._load_extensions(db)
+            await db.execute("PRAGMA foreign_keys = ON")
+            await db.execute(
+                """
+                INSERT INTO support_ledger_update_events (
+                    event_id, entity_type, entity_id, registry, dimension_or_kind,
+                    scope_type, scope_id, old_status, new_status, old_value,
+                    new_value, trigger_case_ids, reason, confidence, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(event_id) DO UPDATE SET
+                    entity_type = excluded.entity_type,
+                    entity_id = excluded.entity_id,
+                    registry = excluded.registry,
+                    dimension_or_kind = excluded.dimension_or_kind,
+                    scope_type = excluded.scope_type,
+                    scope_id = excluded.scope_id,
+                    old_status = excluded.old_status,
+                    new_status = excluded.new_status,
+                    old_value = excluded.old_value,
+                    new_value = excluded.new_value,
+                    trigger_case_ids = excluded.trigger_case_ids,
+                    reason = excluded.reason,
+                    confidence = excluded.confidence,
+                    created_at = excluded.created_at
+                """,
+                (
+                    record["event_id"],
+                    record["entity_type"],
+                    record["entity_id"],
+                    record["registry"],
+                    record["dimension_or_kind"],
+                    record["scope_type"],
+                    record["scope_id"],
+                    record["old_status"],
+                    record["new_status"],
+                    record["old_value"],
+                    record["new_value"],
+                    record["trigger_case_ids"],
+                    record["reason"],
+                    record["confidence"],
+                    record["created_at"],
+                ),
+            )
+            await db.commit()
+
+    async def list_support_ledger_update_events(self) -> list[SupportLedgerUpdateEvent]:
+        """List all v2 support ledger update events in deterministic order."""
+        await self._init()
+
+        import aiosqlite
+
+        async with aiosqlite.connect(self.db_path) as db:
+            await self._load_extensions(db)
+            await db.execute("PRAGMA foreign_keys = ON")
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                """
+                SELECT * FROM support_ledger_update_events
+                ORDER BY created_at ASC, event_id ASC
+                """,
+            ) as cursor:
+                rows = await cursor.fetchall()
+                return [SupportLedgerUpdateEvent.from_record(dict(row)) for row in rows]
 
     async def save_support_pattern(self, pattern: SupportPattern) -> None:
         """Save or update one first-class support pattern."""

--- a/src/alfred/storage/sqlite.py
+++ b/src/alfred/storage/sqlite.py
@@ -3409,6 +3409,26 @@ class SQLiteStore:
         async with aiosqlite.connect(self.db_path) as db:
             await self._load_extensions(db)
             await db.execute("PRAGMA foreign_keys = ON")
+
+            async with db.execute(
+                "SELECT 1 FROM sessions WHERE session_id = ?",
+                (attempt.session_id,),
+            ) as cursor:
+                session_row = await cursor.fetchone()
+            async with db.execute(
+                "SELECT 1 FROM session_messages WHERE session_id = ? AND message_id = ?",
+                (attempt.session_id, attempt.user_message_id),
+            ) as cursor:
+                user_message_row = await cursor.fetchone()
+            async with db.execute(
+                "SELECT 1 FROM session_messages WHERE session_id = ? AND message_id = ?",
+                (attempt.session_id, attempt.assistant_message_id),
+            ) as cursor:
+                assistant_message_row = await cursor.fetchone()
+
+            if session_row is None or user_message_row is None or assistant_message_row is None:
+                raise ValueError("Support attempts require real persisted session/message refs")
+
             await db.execute(
                 """
                 INSERT INTO support_attempts (

--- a/src/alfred/storage/sqlite.py
+++ b/src/alfred/storage/sqlite.py
@@ -14,7 +14,7 @@ from collections.abc import Mapping
 from datetime import datetime
 from pathlib import Path
 from time import perf_counter
-from typing import Any
+from typing import Any, Literal, cast
 
 from alfred.memory.support_learning import (
     LearningCase,
@@ -77,6 +77,82 @@ def _sanitize_json_data(data: Any) -> Any:
     if isinstance(data, list):
         return [_sanitize_json_data(item) for item in data]
     return data
+
+
+_WorkStateEntityType = Literal["arc", "task", "blocker", "open_loop"]
+_WorkStateSignalPolarity = Literal["positive", "negative"]
+
+_TASK_ACTIVE_STATUSES = frozenset({"active", "in_progress", "started"})
+_TASK_COMPLETED_STATUSES = frozenset({"closed", "complete", "completed", "done", "resolved"})
+_TASK_ABANDONED_STATUSES = frozenset({"abandoned", "cancelled", "canceled"})
+_RESOLVED_STATUSES = frozenset({"archived", "closed", "complete", "completed", "done", "resolved"})
+_ARC_STALLED_STATUSES = frozenset({"dormant", "stalled"})
+_ARC_COMPLETED_STATUSES = frozenset({"archived", "complete", "completed", "done"})
+_WORK_STATE_SIGNAL_SPECS: dict[str, tuple[_WorkStateSignalPolarity, float]] = {
+    "task_started": ("positive", 0.76),
+    "task_completed": ("positive", 0.92),
+    "task_abandoned": ("negative", 0.88),
+    "blocker_created": ("negative", 0.72),
+    "blocker_reopened": ("negative", 0.82),
+    "blocker_resolved": ("positive", 0.89),
+    "open_loop_closed": ("positive", 0.84),
+    "open_loop_reopened": ("negative", 0.79),
+    "arc_resumed": ("positive", 0.86),
+    "arc_stalled": ("negative", 0.83),
+    "arc_completed": ("positive", 0.95),
+}
+
+
+def _normalize_status(status: str | None) -> str | None:
+    if status is None:
+        return None
+    normalized = status.strip().lower()
+    return normalized or None
+
+
+def _derive_work_state_transition_signal(
+    *,
+    entity_type: _WorkStateEntityType,
+    previous_status: str | None,
+    current_status: str,
+) -> str | None:
+    previous = _normalize_status(previous_status)
+    current = _normalize_status(current_status)
+    if current is None:
+        return None
+
+    if entity_type == "task":
+        if current in _TASK_COMPLETED_STATUSES and previous not in _TASK_COMPLETED_STATUSES:
+            return "task_completed"
+        if current in _TASK_ABANDONED_STATUSES and previous not in _TASK_ABANDONED_STATUSES:
+            return "task_abandoned"
+        if current in _TASK_ACTIVE_STATUSES and previous not in _TASK_ACTIVE_STATUSES:
+            return "task_started"
+        return None
+
+    if entity_type == "blocker":
+        if current in _RESOLVED_STATUSES and previous not in _RESOLVED_STATUSES:
+            return "blocker_resolved"
+        if previous in _RESOLVED_STATUSES and current not in _RESOLVED_STATUSES:
+            return "blocker_reopened"
+        if previous is None and current not in _RESOLVED_STATUSES:
+            return "blocker_created"
+        return None
+
+    if entity_type == "open_loop":
+        if current in _RESOLVED_STATUSES and previous not in _RESOLVED_STATUSES:
+            return "open_loop_closed"
+        if previous in _RESOLVED_STATUSES and current not in _RESOLVED_STATUSES:
+            return "open_loop_reopened"
+        return None
+
+    if current in _ARC_COMPLETED_STATUSES and previous not in _ARC_COMPLETED_STATUSES:
+        return "arc_completed"
+    if current in _ARC_STALLED_STATUSES and previous not in _ARC_STALLED_STATUSES:
+        return "arc_stalled"
+    if current == "active" and previous in _ARC_STALLED_STATUSES:
+        return "arc_resumed"
+    return None
 
 
 class SQLiteStore:
@@ -1200,6 +1276,10 @@ class SQLiteStore:
             CREATE INDEX IF NOT EXISTS idx_support_attempts_session_created
             ON support_attempts(session_id, created_at ASC, attempt_id ASC)
         """)
+        await db.execute("""
+            CREATE INDEX IF NOT EXISTS idx_support_attempts_arc_created
+            ON support_attempts(active_arc_id, created_at DESC, attempt_id DESC)
+        """)
 
         await db.execute("""
             CREATE TABLE IF NOT EXISTS support_outcome_observations (
@@ -2090,6 +2170,8 @@ class SQLiteStore:
         async with aiosqlite.connect(self.db_path) as db:
             await self._load_extensions(db)
             await db.execute("PRAGMA foreign_keys = ON")
+            db.row_factory = aiosqlite.Row
+            previous_arc = await self._load_operational_arc(db, arc.arc_id)
             record = arc.to_record()
             await db.execute(
                 """
@@ -2121,6 +2203,15 @@ class SQLiteStore:
                     record["evidence_ref_ids"],
                 ),
             )
+            await self._maybe_save_work_state_transition_observation(
+                db,
+                arc_id=arc.arc_id,
+                entity_type="arc",
+                entity_id=arc.arc_id,
+                previous_status=None if previous_arc is None else previous_arc.status,
+                current_status=arc.status,
+                observed_at=arc.updated_at,
+            )
             await db.commit()
 
     async def _load_operational_arc(self, db: Any, arc_id: str) -> OperationalArc | None:
@@ -2143,6 +2234,126 @@ class SQLiteStore:
             await db.execute("PRAGMA foreign_keys = ON")
             db.row_factory = aiosqlite.Row
             return await self._load_operational_arc(db, arc_id)
+
+    async def _load_arc_task_by_id(self, db: Any, task_id: str) -> ArcTask | None:
+        """Load one arc task from an existing SQLite connection."""
+        async with db.execute("SELECT * FROM support_arc_tasks WHERE task_id = ?", (task_id,)) as cursor:
+            row = await cursor.fetchone()
+            if row is None:
+                return None
+        return ArcTask.from_record(dict(row))
+
+    async def _load_arc_blocker_by_id(self, db: Any, blocker_id: str) -> ArcBlocker | None:
+        """Load one arc blocker from an existing SQLite connection."""
+        async with db.execute("SELECT * FROM support_arc_blockers WHERE blocker_id = ?", (blocker_id,)) as cursor:
+            row = await cursor.fetchone()
+            if row is None:
+                return None
+        return ArcBlocker.from_record(dict(row))
+
+    async def _load_arc_open_loop_by_id(self, db: Any, open_loop_id: str) -> ArcOpenLoop | None:
+        """Load one arc open loop from an existing SQLite connection."""
+        async with db.execute("SELECT * FROM support_arc_open_loops WHERE open_loop_id = ?", (open_loop_id,)) as cursor:
+            row = await cursor.fetchone()
+            if row is None:
+                return None
+        return ArcOpenLoop.from_record(dict(row))
+
+    async def _load_latest_support_attempt_for_arc(self, db: Any, arc_id: str) -> SupportAttempt | None:
+        """Load the latest support attempt for one active arc from an existing SQLite connection."""
+        async with db.execute(
+            """
+            SELECT * FROM support_attempts
+            WHERE active_arc_id = ?
+            ORDER BY created_at DESC, attempt_id DESC
+            LIMIT 1
+            """,
+            (arc_id,),
+        ) as cursor:
+            row = await cursor.fetchone()
+            if row is None:
+                return None
+        return SupportAttempt.from_record(dict(row))
+
+    async def _upsert_support_outcome_observation(self, db: Any, observation: OutcomeObservation) -> None:
+        """Insert or update one support outcome observation on an existing SQLite connection."""
+        record = observation.to_record()
+        await db.execute(
+            """
+            INSERT INTO support_outcome_observations (
+                observation_id, attempt_id, observed_at, source_type, signals,
+                signal_polarity, signal_strength, evidence_refs,
+                operational_delta_refs, notes
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(observation_id) DO UPDATE SET
+                attempt_id = excluded.attempt_id,
+                observed_at = excluded.observed_at,
+                source_type = excluded.source_type,
+                signals = excluded.signals,
+                signal_polarity = excluded.signal_polarity,
+                signal_strength = excluded.signal_strength,
+                evidence_refs = excluded.evidence_refs,
+                operational_delta_refs = excluded.operational_delta_refs,
+                notes = excluded.notes
+            """,
+            (
+                record["observation_id"],
+                record["attempt_id"],
+                record["observed_at"],
+                record["source_type"],
+                record["signals"],
+                record["signal_polarity"],
+                record["signal_strength"],
+                record["evidence_refs"],
+                record["operational_delta_refs"],
+                record["notes"],
+            ),
+        )
+
+    async def _maybe_save_work_state_transition_observation(
+        self,
+        db: Any,
+        *,
+        arc_id: str,
+        entity_type: _WorkStateEntityType,
+        entity_id: str,
+        previous_status: str | None,
+        current_status: str,
+        observed_at: datetime,
+    ) -> None:
+        """Persist one deterministic work-state observation when a matching transition exists."""
+        signal = _derive_work_state_transition_signal(
+            entity_type=entity_type,
+            previous_status=previous_status,
+            current_status=current_status,
+        )
+        if signal is None:
+            return
+
+        attempt = await self._load_latest_support_attempt_for_arc(db, arc_id)
+        if attempt is None:
+            return
+
+        signal_polarity, signal_strength = _WORK_STATE_SIGNAL_SPECS[signal]
+        operational_delta_refs: tuple[str, ...] = (f"arc:{arc_id}",)
+        if entity_type != "arc":
+            operational_delta_refs = (*operational_delta_refs, f"{entity_type}:{entity_id}")
+
+        observation = OutcomeObservation(
+            observation_id=(
+                f"obs-{attempt.attempt_id}-{signal}-{entity_type}-{entity_id}-{observed_at.isoformat()}"
+            ),
+            attempt_id=attempt.attempt_id,
+            observed_at=observed_at,
+            source_type="work_state_transition",
+            signals=(signal,),
+            signal_polarity=cast(Any, signal_polarity),
+            signal_strength=signal_strength,
+            evidence_refs=(),
+            operational_delta_refs=operational_delta_refs,
+            notes=None,
+        )
+        await self._upsert_support_outcome_observation(db, observation)
 
     async def list_resume_arcs(self, limit: int = 12) -> list[OperationalArc]:
         """List active and dormant arcs in resume-oriented order across domains."""
@@ -2217,6 +2428,8 @@ class SQLiteStore:
         async with aiosqlite.connect(self.db_path) as db:
             await self._load_extensions(db)
             await db.execute("PRAGMA foreign_keys = ON")
+            db.row_factory = aiosqlite.Row
+            previous_task = await self._load_arc_task_by_id(db, task.task_id)
             record = task.to_record()
             await db.execute(
                 """
@@ -2242,6 +2455,15 @@ class SQLiteStore:
                     record["next_step"],
                     record["evidence_ref_ids"],
                 ),
+            )
+            await self._maybe_save_work_state_transition_observation(
+                db,
+                arc_id=task.arc_id,
+                entity_type="task",
+                entity_id=task.task_id,
+                previous_status=None if previous_task is None else previous_task.status,
+                current_status=task.status,
+                observed_at=task.updated_at,
             )
             await db.commit()
 
@@ -2280,6 +2502,8 @@ class SQLiteStore:
         async with aiosqlite.connect(self.db_path) as db:
             await self._load_extensions(db)
             await db.execute("PRAGMA foreign_keys = ON")
+            db.row_factory = aiosqlite.Row
+            previous_blocker = await self._load_arc_blocker_by_id(db, blocker.blocker_id)
             record = blocker.to_record()
             await db.execute(
                 """
@@ -2305,6 +2529,15 @@ class SQLiteStore:
                     record["next_step"],
                     record["evidence_ref_ids"],
                 ),
+            )
+            await self._maybe_save_work_state_transition_observation(
+                db,
+                arc_id=blocker.arc_id,
+                entity_type="blocker",
+                entity_id=blocker.blocker_id,
+                previous_status=None if previous_blocker is None else previous_blocker.status,
+                current_status=blocker.status,
+                observed_at=blocker.updated_at,
             )
             await db.commit()
 
@@ -2406,6 +2639,8 @@ class SQLiteStore:
         async with aiosqlite.connect(self.db_path) as db:
             await self._load_extensions(db)
             await db.execute("PRAGMA foreign_keys = ON")
+            db.row_factory = aiosqlite.Row
+            previous_open_loop = await self._load_arc_open_loop_by_id(db, open_loop.open_loop_id)
             record = open_loop.to_record()
             await db.execute(
                 """
@@ -2431,6 +2666,15 @@ class SQLiteStore:
                     record["current_tension"],
                     record["evidence_ref_ids"],
                 ),
+            )
+            await self._maybe_save_work_state_transition_observation(
+                db,
+                arc_id=open_loop.arc_id,
+                entity_type="open_loop",
+                entity_id=open_loop.open_loop_id,
+                previous_status=None if previous_open_loop is None else previous_open_loop.status,
+                current_status=open_loop.status,
+                observed_at=open_loop.updated_at,
             )
             await db.commit()
 
@@ -3499,42 +3743,10 @@ class SQLiteStore:
 
         import aiosqlite
 
-        record = observation.to_record()
-
         async with aiosqlite.connect(self.db_path) as db:
             await self._load_extensions(db)
             await db.execute("PRAGMA foreign_keys = ON")
-            await db.execute(
-                """
-                INSERT INTO support_outcome_observations (
-                    observation_id, attempt_id, observed_at, source_type, signals,
-                    signal_polarity, signal_strength, evidence_refs,
-                    operational_delta_refs, notes
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(observation_id) DO UPDATE SET
-                    attempt_id = excluded.attempt_id,
-                    observed_at = excluded.observed_at,
-                    source_type = excluded.source_type,
-                    signals = excluded.signals,
-                    signal_polarity = excluded.signal_polarity,
-                    signal_strength = excluded.signal_strength,
-                    evidence_refs = excluded.evidence_refs,
-                    operational_delta_refs = excluded.operational_delta_refs,
-                    notes = excluded.notes
-                """,
-                (
-                    record["observation_id"],
-                    record["attempt_id"],
-                    record["observed_at"],
-                    record["source_type"],
-                    record["signals"],
-                    record["signal_polarity"],
-                    record["signal_strength"],
-                    record["evidence_refs"],
-                    record["operational_delta_refs"],
-                    record["notes"],
-                ),
-            )
+            await self._upsert_support_outcome_observation(db, observation)
             await db.commit()
 
     async def list_support_outcome_observations(self, attempt_id: str) -> list[OutcomeObservation]:

--- a/src/alfred/storage/sqlite.py
+++ b/src/alfred/storage/sqlite.py
@@ -17,15 +17,19 @@ from time import perf_counter
 from typing import Any, Literal, cast
 
 from alfred.memory.support_learning import (
+    FinalizedLearningCaseBundle,
     LearningCase,
     LearningSituation,
     OutcomeObservation,
     SupportAttempt,
+    SupportLedgerDerivationResult,
     SupportLedgerUpdateEvent,
     SupportPattern,
     SupportPatternLedgerEntry,
     SupportProfileUpdateEvent,
     SupportValueLedgerEntry,
+    derive_learning_case,
+    derive_value_ledger_updates_from_cases,
 )
 from alfred.memory.support_memory import (
     ArcBlocker,
@@ -3721,6 +3725,14 @@ class SQLiteStore:
             )
             await db.commit()
 
+    async def _load_support_attempt_by_id(self, db: Any, attempt_id: str) -> SupportAttempt | None:
+        """Load one v2 support attempt from an existing SQLite connection."""
+        async with db.execute("SELECT * FROM support_attempts WHERE attempt_id = ?", (attempt_id,)) as cursor:
+            row = await cursor.fetchone()
+            if row is None:
+                return None
+        return SupportAttempt.from_record(dict(row))
+
     async def get_support_attempt(self, attempt_id: str) -> SupportAttempt | None:
         """Load one v2 support attempt by ID."""
         await self._init()
@@ -3731,11 +3743,7 @@ class SQLiteStore:
             await self._load_extensions(db)
             await db.execute("PRAGMA foreign_keys = ON")
             db.row_factory = aiosqlite.Row
-            async with db.execute("SELECT * FROM support_attempts WHERE attempt_id = ?", (attempt_id,)) as cursor:
-                row = await cursor.fetchone()
-                if row is None:
-                    return None
-                return SupportAttempt.from_record(dict(row))
+            return await self._load_support_attempt_by_id(db, attempt_id)
 
     async def save_support_outcome_observation(self, observation: OutcomeObservation) -> None:
         """Save or update one v2 support outcome observation."""
@@ -3749,6 +3757,19 @@ class SQLiteStore:
             await self._upsert_support_outcome_observation(db, observation)
             await db.commit()
 
+    async def _load_support_outcome_observations(self, db: Any, attempt_id: str) -> list[OutcomeObservation]:
+        """Load v2 support observations for one attempt from an existing SQLite connection."""
+        async with db.execute(
+            """
+            SELECT * FROM support_outcome_observations
+            WHERE attempt_id = ?
+            ORDER BY observed_at ASC, observation_id ASC
+            """,
+            (attempt_id,),
+        ) as cursor:
+            rows = await cursor.fetchall()
+        return [OutcomeObservation.from_record(dict(row)) for row in rows]
+
     async def list_support_outcome_observations(self, attempt_id: str) -> list[OutcomeObservation]:
         """List v2 support observations for one attempt in chronological order."""
         await self._init()
@@ -3759,16 +3780,80 @@ class SQLiteStore:
             await self._load_extensions(db)
             await db.execute("PRAGMA foreign_keys = ON")
             db.row_factory = aiosqlite.Row
-            async with db.execute(
-                """
-                SELECT * FROM support_outcome_observations
-                WHERE attempt_id = ?
-                ORDER BY observed_at ASC, observation_id ASC
-                """,
-                (attempt_id,),
-            ) as cursor:
-                rows = await cursor.fetchall()
-                return [OutcomeObservation.from_record(dict(row)) for row in rows]
+            return await self._load_support_outcome_observations(db, attempt_id)
+
+    async def _upsert_support_learning_case(self, db: Any, learning_case: LearningCase) -> None:
+        """Insert or update one v2 support learning case on an existing SQLite connection."""
+        record = learning_case.to_record()
+        await db.execute(
+            """
+            INSERT INTO support_learning_cases (
+                case_id, attempt_id, status, scope_type, scope_id,
+                created_at, finalized_at, aggregate_signals,
+                positive_evidence_count, negative_evidence_count,
+                contradiction_count, conversation_score,
+                operational_score, overall_score,
+                promotion_eligibility, evidence_refs, summary
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(case_id) DO UPDATE SET
+                attempt_id = excluded.attempt_id,
+                status = excluded.status,
+                scope_type = excluded.scope_type,
+                scope_id = excluded.scope_id,
+                created_at = excluded.created_at,
+                finalized_at = excluded.finalized_at,
+                aggregate_signals = excluded.aggregate_signals,
+                positive_evidence_count = excluded.positive_evidence_count,
+                negative_evidence_count = excluded.negative_evidence_count,
+                contradiction_count = excluded.contradiction_count,
+                conversation_score = excluded.conversation_score,
+                operational_score = excluded.operational_score,
+                overall_score = excluded.overall_score,
+                promotion_eligibility = excluded.promotion_eligibility,
+                evidence_refs = excluded.evidence_refs,
+                summary = excluded.summary
+            """,
+            (
+                record["case_id"],
+                record["attempt_id"],
+                record["status"],
+                record["scope_type"],
+                record["scope_id"],
+                record["created_at"],
+                record["finalized_at"],
+                record["aggregate_signals"],
+                record["positive_evidence_count"],
+                record["negative_evidence_count"],
+                record["contradiction_count"],
+                record["conversation_score"],
+                record["operational_score"],
+                record["overall_score"],
+                int(record["promotion_eligibility"]),
+                record["evidence_refs"],
+                record["summary"],
+            ),
+        )
+
+    async def finalize_support_learning_case(self, attempt_id: str) -> LearningCase | None:
+        """Derive and persist one deterministic learning case for a stored attempt bundle."""
+        await self._init()
+
+        import aiosqlite
+
+        async with aiosqlite.connect(self.db_path) as db:
+            await self._load_extensions(db)
+            await db.execute("PRAGMA foreign_keys = ON")
+            db.row_factory = aiosqlite.Row
+            attempt = await self._load_support_attempt_by_id(db, attempt_id)
+            if attempt is None:
+                return None
+            observations = await self._load_support_outcome_observations(db, attempt_id)
+            learning_case = derive_learning_case(attempt=attempt, observations=observations)
+            if learning_case is None:
+                return None
+            await self._upsert_support_learning_case(db, learning_case)
+            await db.commit()
+            return learning_case
 
     async def save_support_learning_case(self, learning_case: LearningCase) -> None:
         """Save or update one v2 support learning case."""
@@ -3776,60 +3861,36 @@ class SQLiteStore:
 
         import aiosqlite
 
-        record = learning_case.to_record()
-
         async with aiosqlite.connect(self.db_path) as db:
             await self._load_extensions(db)
             await db.execute("PRAGMA foreign_keys = ON")
-            await db.execute(
-                """
-                INSERT INTO support_learning_cases (
-                    case_id, attempt_id, status, scope_type, scope_id,
-                    created_at, finalized_at, aggregate_signals,
-                    positive_evidence_count, negative_evidence_count,
-                    contradiction_count, conversation_score,
-                    operational_score, overall_score,
-                    promotion_eligibility, evidence_refs, summary
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(case_id) DO UPDATE SET
-                    attempt_id = excluded.attempt_id,
-                    status = excluded.status,
-                    scope_type = excluded.scope_type,
-                    scope_id = excluded.scope_id,
-                    created_at = excluded.created_at,
-                    finalized_at = excluded.finalized_at,
-                    aggregate_signals = excluded.aggregate_signals,
-                    positive_evidence_count = excluded.positive_evidence_count,
-                    negative_evidence_count = excluded.negative_evidence_count,
-                    contradiction_count = excluded.contradiction_count,
-                    conversation_score = excluded.conversation_score,
-                    operational_score = excluded.operational_score,
-                    overall_score = excluded.overall_score,
-                    promotion_eligibility = excluded.promotion_eligibility,
-                    evidence_refs = excluded.evidence_refs,
-                    summary = excluded.summary
-                """,
-                (
-                    record["case_id"],
-                    record["attempt_id"],
-                    record["status"],
-                    record["scope_type"],
-                    record["scope_id"],
-                    record["created_at"],
-                    record["finalized_at"],
-                    record["aggregate_signals"],
-                    record["positive_evidence_count"],
-                    record["negative_evidence_count"],
-                    record["contradiction_count"],
-                    record["conversation_score"],
-                    record["operational_score"],
-                    record["overall_score"],
-                    int(record["promotion_eligibility"]),
-                    record["evidence_refs"],
-                    record["summary"],
-                ),
-            )
+            await self._upsert_support_learning_case(db, learning_case)
             await db.commit()
+
+    async def _load_support_learning_case_by_id(self, db: Any, case_id: str) -> LearningCase | None:
+        """Load one v2 support learning case from an existing SQLite connection."""
+        async with db.execute("SELECT * FROM support_learning_cases WHERE case_id = ?", (case_id,)) as cursor:
+            row = await cursor.fetchone()
+            if row is None:
+                return None
+        return LearningCase.from_record(dict(row))
+
+    async def _load_support_learning_cases_for_scope(
+        self,
+        db: Any,
+        scope: SupportProfileScope,
+    ) -> list[LearningCase]:
+        """Load v2 support learning cases for one exact scope from an existing SQLite connection."""
+        async with db.execute(
+            """
+            SELECT * FROM support_learning_cases
+            WHERE scope_type = ? AND scope_id = ?
+            ORDER BY finalized_at ASC, case_id ASC
+            """,
+            (scope.type, scope.id),
+        ) as cursor:
+            rows = await cursor.fetchall()
+        return [LearningCase.from_record(dict(row)) for row in rows]
 
     async def get_support_learning_case(self, case_id: str) -> LearningCase | None:
         """Load one v2 support learning case by ID."""
@@ -3841,11 +3902,53 @@ class SQLiteStore:
             await self._load_extensions(db)
             await db.execute("PRAGMA foreign_keys = ON")
             db.row_factory = aiosqlite.Row
-            async with db.execute("SELECT * FROM support_learning_cases WHERE case_id = ?", (case_id,)) as cursor:
-                row = await cursor.fetchone()
-                if row is None:
-                    return None
-                return LearningCase.from_record(dict(row))
+            return await self._load_support_learning_case_by_id(db, case_id)
+
+    async def _upsert_support_value_ledger_entry(self, db: Any, value_entry: SupportValueLedgerEntry) -> None:
+        """Insert or update one v2 support value ledger entry on an existing SQLite connection."""
+        record = value_entry.to_record()
+        await db.execute(
+            """
+            INSERT INTO support_value_ledger_entries (
+                value_id, registry, dimension, scope_type, scope_id, value,
+                status, source, confidence, evidence_count,
+                contradiction_count, last_case_id, created_at,
+                updated_at, why
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(value_id) DO UPDATE SET
+                registry = excluded.registry,
+                dimension = excluded.dimension,
+                scope_type = excluded.scope_type,
+                scope_id = excluded.scope_id,
+                value = excluded.value,
+                status = excluded.status,
+                source = excluded.source,
+                confidence = excluded.confidence,
+                evidence_count = excluded.evidence_count,
+                contradiction_count = excluded.contradiction_count,
+                last_case_id = excluded.last_case_id,
+                created_at = excluded.created_at,
+                updated_at = excluded.updated_at,
+                why = excluded.why
+            """,
+            (
+                record["value_id"],
+                record["registry"],
+                record["dimension"],
+                record["scope_type"],
+                record["scope_id"],
+                record["value"],
+                record["status"],
+                record["source"],
+                record["confidence"],
+                record["evidence_count"],
+                record["contradiction_count"],
+                record["last_case_id"],
+                record["created_at"],
+                record["updated_at"],
+                record["why"],
+            ),
+        )
 
     async def save_support_value_ledger_entry(self, value_entry: SupportValueLedgerEntry) -> None:
         """Save or update one v2 support value ledger entry."""
@@ -3853,54 +3956,28 @@ class SQLiteStore:
 
         import aiosqlite
 
-        record = value_entry.to_record()
-
         async with aiosqlite.connect(self.db_path) as db:
             await self._load_extensions(db)
             await db.execute("PRAGMA foreign_keys = ON")
-            await db.execute(
-                """
-                INSERT INTO support_value_ledger_entries (
-                    value_id, registry, dimension, scope_type, scope_id, value,
-                    status, source, confidence, evidence_count,
-                    contradiction_count, last_case_id, created_at,
-                    updated_at, why
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(value_id) DO UPDATE SET
-                    registry = excluded.registry,
-                    dimension = excluded.dimension,
-                    scope_type = excluded.scope_type,
-                    scope_id = excluded.scope_id,
-                    value = excluded.value,
-                    status = excluded.status,
-                    source = excluded.source,
-                    confidence = excluded.confidence,
-                    evidence_count = excluded.evidence_count,
-                    contradiction_count = excluded.contradiction_count,
-                    last_case_id = excluded.last_case_id,
-                    created_at = excluded.created_at,
-                    updated_at = excluded.updated_at,
-                    why = excluded.why
-                """,
-                (
-                    record["value_id"],
-                    record["registry"],
-                    record["dimension"],
-                    record["scope_type"],
-                    record["scope_id"],
-                    record["value"],
-                    record["status"],
-                    record["source"],
-                    record["confidence"],
-                    record["evidence_count"],
-                    record["contradiction_count"],
-                    record["last_case_id"],
-                    record["created_at"],
-                    record["updated_at"],
-                    record["why"],
-                ),
-            )
+            await self._upsert_support_value_ledger_entry(db, value_entry)
             await db.commit()
+
+    async def _load_support_value_ledger_entries_for_scope(
+        self,
+        db: Any,
+        scope: SupportProfileScope,
+    ) -> list[SupportValueLedgerEntry]:
+        """Load v2 support value-ledger entries for one exact scope from an existing SQLite connection."""
+        async with db.execute(
+            """
+            SELECT * FROM support_value_ledger_entries
+            WHERE scope_type = ? AND scope_id = ?
+            ORDER BY registry ASC, dimension ASC, value_id ASC
+            """,
+            (scope.type, scope.id),
+        ) as cursor:
+            rows = await cursor.fetchall()
+        return [SupportValueLedgerEntry.from_record(dict(row)) for row in rows]
 
     async def list_support_value_ledger_entries(self) -> list[SupportValueLedgerEntry]:
         """List all v2 support value ledger entries in deterministic order."""
@@ -3992,58 +4069,116 @@ class SQLiteStore:
                     return None
                 return SupportPatternLedgerEntry.from_record(dict(row))
 
+    async def _upsert_support_ledger_update_event(self, db: Any, event: SupportLedgerUpdateEvent) -> None:
+        """Insert or update one v2 support ledger update event on an existing SQLite connection."""
+        record = event.to_record()
+        await db.execute(
+            """
+            INSERT INTO support_ledger_update_events (
+                event_id, entity_type, entity_id, registry, dimension_or_kind,
+                scope_type, scope_id, old_status, new_status, old_value,
+                new_value, trigger_case_ids, reason, confidence, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(event_id) DO UPDATE SET
+                entity_type = excluded.entity_type,
+                entity_id = excluded.entity_id,
+                registry = excluded.registry,
+                dimension_or_kind = excluded.dimension_or_kind,
+                scope_type = excluded.scope_type,
+                scope_id = excluded.scope_id,
+                old_status = excluded.old_status,
+                new_status = excluded.new_status,
+                old_value = excluded.old_value,
+                new_value = excluded.new_value,
+                trigger_case_ids = excluded.trigger_case_ids,
+                reason = excluded.reason,
+                confidence = excluded.confidence,
+                created_at = excluded.created_at
+            """,
+            (
+                record["event_id"],
+                record["entity_type"],
+                record["entity_id"],
+                record["registry"],
+                record["dimension_or_kind"],
+                record["scope_type"],
+                record["scope_id"],
+                record["old_status"],
+                record["new_status"],
+                record["old_value"],
+                record["new_value"],
+                record["trigger_case_ids"],
+                record["reason"],
+                record["confidence"],
+                record["created_at"],
+            ),
+        )
+
+    async def apply_support_case_learning(self, case_id: str) -> SupportLedgerDerivationResult | None:
+        """Derive and persist v2 value-ledger updates for one finalized support-learning case."""
+        await self._init()
+
+        import aiosqlite
+
+        async with aiosqlite.connect(self.db_path) as db:
+            await self._load_extensions(db)
+            await db.execute("PRAGMA foreign_keys = ON")
+            db.row_factory = aiosqlite.Row
+
+            learning_case = await self._load_support_learning_case_by_id(db, case_id)
+            if learning_case is None or learning_case.status != "complete" or not learning_case.promotion_eligibility:
+                return None
+
+            attempt = await self._load_support_attempt_by_id(db, learning_case.attempt_id)
+            if attempt is None or learning_case.finalized_at is None:
+                return None
+
+            focus_bundle = FinalizedLearningCaseBundle(learning_case=learning_case, attempt=attempt)
+            scoped_bundles: list[FinalizedLearningCaseBundle] = []
+            for scoped_case in await self._load_support_learning_cases_for_scope(db, learning_case.scope):
+                if scoped_case.finalized_at is None:
+                    continue
+                scoped_attempt = await self._load_support_attempt_by_id(db, scoped_case.attempt_id)
+                if scoped_attempt is None:
+                    continue
+                scoped_bundles.append(FinalizedLearningCaseBundle(learning_case=scoped_case, attempt=scoped_attempt))
+
+            existing_value_entries = {
+                (
+                    entry.registry,
+                    entry.dimension,
+                    entry.scope.type,
+                    entry.scope.id,
+                    entry.value,
+                ): entry
+                for entry in await self._load_support_value_ledger_entries_for_scope(db, learning_case.scope)
+            }
+            result = derive_value_ledger_updates_from_cases(
+                focus_bundle=focus_bundle,
+                scoped_bundles=tuple(scoped_bundles),
+                existing_value_entries=existing_value_entries,
+                now=learning_case.finalized_at,
+            )
+            if not result.value_entries and not result.update_events:
+                return None
+
+            for value_entry in result.value_entries:
+                await self._upsert_support_value_ledger_entry(db, value_entry)
+            for event in result.update_events:
+                await self._upsert_support_ledger_update_event(db, event)
+            await db.commit()
+            return result
+
     async def save_support_ledger_update_event(self, event: SupportLedgerUpdateEvent) -> None:
         """Save or update one v2 support ledger update event."""
         await self._init()
 
         import aiosqlite
 
-        record = event.to_record()
-
         async with aiosqlite.connect(self.db_path) as db:
             await self._load_extensions(db)
             await db.execute("PRAGMA foreign_keys = ON")
-            await db.execute(
-                """
-                INSERT INTO support_ledger_update_events (
-                    event_id, entity_type, entity_id, registry, dimension_or_kind,
-                    scope_type, scope_id, old_status, new_status, old_value,
-                    new_value, trigger_case_ids, reason, confidence, created_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(event_id) DO UPDATE SET
-                    entity_type = excluded.entity_type,
-                    entity_id = excluded.entity_id,
-                    registry = excluded.registry,
-                    dimension_or_kind = excluded.dimension_or_kind,
-                    scope_type = excluded.scope_type,
-                    scope_id = excluded.scope_id,
-                    old_status = excluded.old_status,
-                    new_status = excluded.new_status,
-                    old_value = excluded.old_value,
-                    new_value = excluded.new_value,
-                    trigger_case_ids = excluded.trigger_case_ids,
-                    reason = excluded.reason,
-                    confidence = excluded.confidence,
-                    created_at = excluded.created_at
-                """,
-                (
-                    record["event_id"],
-                    record["entity_type"],
-                    record["entity_id"],
-                    record["registry"],
-                    record["dimension_or_kind"],
-                    record["scope_type"],
-                    record["scope_id"],
-                    record["old_status"],
-                    record["new_status"],
-                    record["old_value"],
-                    record["new_value"],
-                    record["trigger_case_ids"],
-                    record["reason"],
-                    record["confidence"],
-                    record["created_at"],
-                ),
-            )
+            await self._upsert_support_ledger_update_event(db, event)
             await db.commit()
 
     async def list_support_ledger_update_events(self) -> list[SupportLedgerUpdateEvent]:

--- a/src/alfred/storage/sqlite.py
+++ b/src/alfred/storage/sqlite.py
@@ -2359,6 +2359,16 @@ class SQLiteStore:
         )
         await self._upsert_support_outcome_observation(db, observation)
 
+        learning_case = await self._finalize_support_learning_case_in_tx(db, attempt.attempt_id)
+        if (
+            learning_case is None
+            or learning_case.status != "complete"
+            or not learning_case.promotion_eligibility
+        ):
+            return
+
+        await self._apply_support_case_learning_in_tx(db, learning_case.case_id)
+
     async def list_resume_arcs(self, limit: int = 12) -> list[OperationalArc]:
         """List active and dormant arcs in resume-oriented order across domains."""
         await self._init()
@@ -3834,6 +3844,18 @@ class SQLiteStore:
             ),
         )
 
+    async def _finalize_support_learning_case_in_tx(self, db: Any, attempt_id: str) -> LearningCase | None:
+        """Derive + upsert one deterministic learning case on an existing SQLite connection."""
+        attempt = await self._load_support_attempt_by_id(db, attempt_id)
+        if attempt is None:
+            return None
+        observations = await self._load_support_outcome_observations(db, attempt_id)
+        learning_case = derive_learning_case(attempt=attempt, observations=observations)
+        if learning_case is None:
+            return None
+        await self._upsert_support_learning_case(db, learning_case)
+        return learning_case
+
     async def finalize_support_learning_case(self, attempt_id: str) -> LearningCase | None:
         """Derive and persist one deterministic learning case for a stored attempt bundle."""
         await self._init()
@@ -3844,14 +3866,9 @@ class SQLiteStore:
             await self._load_extensions(db)
             await db.execute("PRAGMA foreign_keys = ON")
             db.row_factory = aiosqlite.Row
-            attempt = await self._load_support_attempt_by_id(db, attempt_id)
-            if attempt is None:
-                return None
-            observations = await self._load_support_outcome_observations(db, attempt_id)
-            learning_case = derive_learning_case(attempt=attempt, observations=observations)
+            learning_case = await self._finalize_support_learning_case_in_tx(db, attempt_id)
             if learning_case is None:
                 return None
-            await self._upsert_support_learning_case(db, learning_case)
             await db.commit()
             return learning_case
 
@@ -4114,6 +4131,55 @@ class SQLiteStore:
             ),
         )
 
+    async def _apply_support_case_learning_in_tx(
+        self,
+        db: Any,
+        case_id: str,
+    ) -> SupportLedgerDerivationResult | None:
+        """Derive + upsert v2 value-ledger updates on an existing SQLite connection."""
+        learning_case = await self._load_support_learning_case_by_id(db, case_id)
+        if learning_case is None or learning_case.status != "complete" or not learning_case.promotion_eligibility:
+            return None
+
+        attempt = await self._load_support_attempt_by_id(db, learning_case.attempt_id)
+        if attempt is None or learning_case.finalized_at is None:
+            return None
+
+        focus_bundle = FinalizedLearningCaseBundle(learning_case=learning_case, attempt=attempt)
+        scoped_bundles: list[FinalizedLearningCaseBundle] = []
+        for scoped_case in await self._load_support_learning_cases_for_scope(db, learning_case.scope):
+            if scoped_case.finalized_at is None:
+                continue
+            scoped_attempt = await self._load_support_attempt_by_id(db, scoped_case.attempt_id)
+            if scoped_attempt is None:
+                continue
+            scoped_bundles.append(FinalizedLearningCaseBundle(learning_case=scoped_case, attempt=scoped_attempt))
+
+        existing_value_entries = {
+            (
+                entry.registry,
+                entry.dimension,
+                entry.scope.type,
+                entry.scope.id,
+                entry.value,
+            ): entry
+            for entry in await self._load_support_value_ledger_entries_for_scope(db, learning_case.scope)
+        }
+        result = derive_value_ledger_updates_from_cases(
+            focus_bundle=focus_bundle,
+            scoped_bundles=tuple(scoped_bundles),
+            existing_value_entries=existing_value_entries,
+            now=learning_case.finalized_at,
+        )
+        if not result.value_entries and not result.update_events:
+            return None
+
+        for value_entry in result.value_entries:
+            await self._upsert_support_value_ledger_entry(db, value_entry)
+        for event in result.update_events:
+            await self._upsert_support_ledger_update_event(db, event)
+        return result
+
     async def apply_support_case_learning(self, case_id: str) -> SupportLedgerDerivationResult | None:
         """Derive and persist v2 value-ledger updates for one finalized support-learning case."""
         await self._init()
@@ -4125,47 +4191,9 @@ class SQLiteStore:
             await db.execute("PRAGMA foreign_keys = ON")
             db.row_factory = aiosqlite.Row
 
-            learning_case = await self._load_support_learning_case_by_id(db, case_id)
-            if learning_case is None or learning_case.status != "complete" or not learning_case.promotion_eligibility:
+            result = await self._apply_support_case_learning_in_tx(db, case_id)
+            if result is None:
                 return None
-
-            attempt = await self._load_support_attempt_by_id(db, learning_case.attempt_id)
-            if attempt is None or learning_case.finalized_at is None:
-                return None
-
-            focus_bundle = FinalizedLearningCaseBundle(learning_case=learning_case, attempt=attempt)
-            scoped_bundles: list[FinalizedLearningCaseBundle] = []
-            for scoped_case in await self._load_support_learning_cases_for_scope(db, learning_case.scope):
-                if scoped_case.finalized_at is None:
-                    continue
-                scoped_attempt = await self._load_support_attempt_by_id(db, scoped_case.attempt_id)
-                if scoped_attempt is None:
-                    continue
-                scoped_bundles.append(FinalizedLearningCaseBundle(learning_case=scoped_case, attempt=scoped_attempt))
-
-            existing_value_entries = {
-                (
-                    entry.registry,
-                    entry.dimension,
-                    entry.scope.type,
-                    entry.scope.id,
-                    entry.value,
-                ): entry
-                for entry in await self._load_support_value_ledger_entries_for_scope(db, learning_case.scope)
-            }
-            result = derive_value_ledger_updates_from_cases(
-                focus_bundle=focus_bundle,
-                scoped_bundles=tuple(scoped_bundles),
-                existing_value_entries=existing_value_entries,
-                now=learning_case.finalized_at,
-            )
-            if not result.value_entries and not result.update_events:
-                return None
-
-            for value_entry in result.value_entries:
-                await self._upsert_support_value_ledger_entry(db, value_entry)
-            for event in result.update_events:
-                await self._upsert_support_ledger_update_event(db, event)
             await db.commit()
             return result
 

--- a/src/alfred/support_policy.py
+++ b/src/alfred/support_policy.py
@@ -22,6 +22,7 @@ from alfred.embeddings import cosine_similarity
 from alfred.memory.support_context import ArcResumeContext, get_support_operational_context
 from alfred.memory.support_learning import (
     LearningSituation,
+    SupportAttempt,
     SupportPattern,
     SupportProfileUpdateEvent,
     apply_bounded_adaptation,
@@ -1238,6 +1239,38 @@ class SupportPolicyRuntime:
             similar_situations=similar_situations,
             existing_profile_values=existing_profile_values,
             now=datetime.now(UTC),
+        )
+
+    def build_support_attempt(
+        self,
+        *,
+        runtime_result: SupportPolicyRuntimeResult,
+        session_id: str,
+        user_message_id: str,
+        assistant_message_id: str,
+        created_at: datetime,
+    ) -> SupportAttempt:
+        """Build one typed v2 support attempt from the reply-time runtime result."""
+        assessment = runtime_result.assessment
+        resolved_policy = runtime_result.resolved_policy
+        behavior_contract = runtime_result.behavior_contract
+        return SupportAttempt(
+            attempt_id=f"attempt-{assistant_message_id}",
+            session_id=session_id,
+            user_message_id=user_message_id,
+            assistant_message_id=assistant_message_id,
+            created_at=created_at,
+            need=assessment.need,
+            response_mode=runtime_result.response_mode,
+            subject_refs=tuple(_format_subject(subject) for subject in assessment.subjects),
+            active_arc_id=resolved_policy.primary_arc_id,
+            active_domain_ids=resolved_policy.domain_ids,
+            effective_support_values=dict(behavior_contract.support_values),
+            effective_relational_values=dict(behavior_contract.relational_values),
+            intervention_family=behavior_contract.intervention_family,
+            intervention_refs=(),
+            prompt_contract_summary=_summarize_contract_for_learning(behavior_contract),
+            operational_snapshot_ref=None,
         )
 
     async def build_turn_contract(

--- a/src/alfred/support_policy.py
+++ b/src/alfred/support_policy.py
@@ -15,8 +15,8 @@ import re
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any, Literal, Protocol, cast
+from datetime import datetime
+from typing import TYPE_CHECKING, Literal, Protocol, cast
 
 from alfred.embeddings import cosine_similarity
 from alfred.memory.support_context import ArcResumeContext, get_support_operational_context
@@ -25,7 +25,6 @@ from alfred.memory.support_learning import (
     SupportAttempt,
     SupportPattern,
     SupportProfileUpdateEvent,
-    apply_bounded_adaptation,
 )
 from alfred.memory.support_memory import LifeDomain, OperationalArc
 from alfred.memory.support_profile import (
@@ -1200,46 +1199,13 @@ class SupportPolicyRuntime:
         turn_text: str,
         session_id: str | None,
     ) -> None:
-        if query_embedding is None:
-            return
+        """Legacy bounded adaptation hook.
 
-        similar_situations = await self._store.search_learning_situations(
-            list(query_embedding),
-            top_k=6,
-            response_mode=response_mode,
-            need=None if assessment.need == "unknown" else assessment.need,
-        )
-        existing_profile_values = await self._load_existing_profile_values(
-            assessment=assessment,
-            response_mode=response_mode,
-        )
-        subject_refs = tuple(_format_subject(subject) for subject in assessment.subjects)
-        domain_ids = tuple(subject.id for subject in assessment.subjects if subject.kind == "domain" and subject.id is not None)
-        current_situation = LearningSituation(
-            situation_id=f"sit-{int(datetime.now(UTC).timestamp() * 1000)}",
-            session_id=session_id or "runtime",
-            recorded_at=datetime.now(UTC),
-            turn_text=turn_text,
-            embedding=tuple(float(value) for value in query_embedding),
-            need=assessment.need,
-            response_mode=response_mode,
-            subject_refs=subject_refs,
-            arc_id=resolved_policy.primary_arc_id,
-            domain_ids=domain_ids,
-            intervention_ids=(),
-            behavior_contract_summary=_summarize_contract_for_learning(behavior_contract),
-            intervention_family=behavior_contract.intervention_family,
-            relational_values_applied=dict(behavior_contract.relational_values),
-            support_values_applied=dict(behavior_contract.support_values),
-            evidence_refs=(),
-        )
-        await apply_bounded_adaptation(
-            store=cast(Any, self._store),
-            current_situation=current_situation,
-            similar_situations=similar_situations,
-            existing_profile_values=existing_profile_values,
-            now=datetime.now(UTC),
-        )
+        PRD #183 Milestone 4B.2 (Option A): bounded (turn-centric) adaptation is retired.
+        Case-derived v2 learning should be the only path that updates learned values.
+        """
+        del assessment, response_mode, query_embedding, behavior_contract, resolved_policy, turn_text, session_id
+        return
 
     def build_support_attempt(
         self,
@@ -1350,18 +1316,6 @@ class SupportPolicyRuntime:
             turn_text=message,
             session_id=session_id,
         )
-        if query_embedding is not None:
-            runtime_patterns = await self._load_runtime_patterns(
-                assessment=assessment_result.assessment,
-                response_mode=response_mode,
-            )
-            resolved_policy = await resolve_support_policy(
-                store=cast(SupportPolicyStore, self._store),
-                assessment=assessment_result.assessment,
-                response_mode=response_mode,
-                patterns=runtime_patterns,
-            )
-            behavior_contract = compile_support_behavior_contract(resolved_policy)
         return SupportPolicyRuntimeResult(
             assessment=assessment_result.assessment,
             response_mode=response_mode,

--- a/src/alfred/support_policy.py
+++ b/src/alfred/support_policy.py
@@ -1273,6 +1273,30 @@ class SupportPolicyRuntime:
             operational_snapshot_ref=None,
         )
 
+    async def save_support_attempt(
+        self,
+        *,
+        runtime_result: SupportPolicyRuntimeResult,
+        session_id: str,
+        user_message_id: str,
+        assistant_message_id: str,
+        created_at: datetime,
+    ) -> SupportAttempt:
+        """Persist one reply-time v2 support attempt when the store supports it."""
+        save_support_attempt = getattr(self._store, "save_support_attempt", None)
+        if not callable(save_support_attempt):
+            raise RuntimeError("Support-policy store does not support v2 support-attempt persistence")
+
+        attempt = self.build_support_attempt(
+            runtime_result=runtime_result,
+            session_id=session_id,
+            user_message_id=user_message_id,
+            assistant_message_id=assistant_message_id,
+            created_at=created_at,
+        )
+        await save_support_attempt(attempt)
+        return attempt
+
     async def build_turn_contract(
         self,
         *,

--- a/src/alfred/support_reflection.py
+++ b/src/alfred/support_reflection.py
@@ -4,9 +4,15 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Literal, Protocol, cast
+from typing import Any, Literal, Protocol, TypedDict, cast
 
-from alfred.memory.support_learning import LearningSituation, SupportPattern, SupportProfileUpdateEvent
+from alfred.memory.support_learning import (
+    LearningSituation,
+    SupportLedgerUpdateEvent,
+    SupportPattern,
+    SupportProfileUpdateEvent,
+    SupportValueLedgerEntry,
+)
 from alfred.memory.support_memory import LifeDomain, OperationalArc
 from alfred.memory.support_profile import (
     SupportProfileScope,
@@ -248,6 +254,82 @@ class UpdateEventSummary:
         )
 
 
+class ValueLedgerSummary(TypedDict):
+    total: int
+    counts_by_status: dict[str, int]
+    counts_by_registry: dict[str, int]
+
+
+@dataclass(frozen=True)
+class SupportValueLedgerEntrySummary:
+    value_id: str
+    registry: str
+    dimension: str
+    scope: SupportProfileScope
+    value: str
+    status: str
+    confidence: float
+    evidence_count: int
+    contradiction_count: int
+    last_case_id: str | None
+    updated_at: datetime
+    why: str
+
+    @classmethod
+    def from_entry(cls, entry: SupportValueLedgerEntry) -> SupportValueLedgerEntrySummary:
+        return cls(
+            value_id=entry.value_id,
+            registry=str(entry.registry),
+            dimension=entry.dimension,
+            scope=entry.scope,
+            value=entry.value,
+            status=str(entry.status),
+            confidence=entry.confidence,
+            evidence_count=entry.evidence_count,
+            contradiction_count=entry.contradiction_count,
+            last_case_id=entry.last_case_id,
+            updated_at=entry.updated_at,
+            why=entry.why,
+        )
+
+
+@dataclass(frozen=True)
+class LedgerUpdateEventSummary:
+    event_id: str
+    entity_type: str
+    entity_id: str
+    registry: str
+    dimension_or_kind: str
+    scope: SupportProfileScope
+    old_status: str | None
+    new_status: str
+    old_value: str | None
+    new_value: str | None
+    trigger_case_ids: tuple[str, ...]
+    reason: str
+    confidence: float
+    created_at: datetime
+
+    @classmethod
+    def from_event(cls, event: SupportLedgerUpdateEvent) -> LedgerUpdateEventSummary:
+        return cls(
+            event_id=event.event_id,
+            entity_type=str(event.entity_type),
+            entity_id=event.entity_id,
+            registry=str(event.registry),
+            dimension_or_kind=event.dimension_or_kind,
+            scope=event.scope,
+            old_status=None if event.old_status is None else str(event.old_status),
+            new_status=str(event.new_status),
+            old_value=event.old_value,
+            new_value=event.new_value,
+            trigger_case_ids=event.trigger_case_ids,
+            reason=event.reason,
+            confidence=event.confidence,
+            created_at=event.created_at,
+        )
+
+
 @dataclass(frozen=True)
 class LearningSituationSummary:
     situation_id: str
@@ -289,6 +371,9 @@ class LearnedState:
     candidate_patterns: tuple[PatternSummary, ...]
     confirmed_patterns: tuple[PatternSummary, ...]
     recent_update_events: tuple[UpdateEventSummary, ...]
+    value_ledger_entries: tuple[SupportValueLedgerEntrySummary, ...]
+    value_ledger_summary: ValueLedgerSummary
+    recent_ledger_update_events: tuple[LedgerUpdateEventSummary, ...]
     recent_interventions: tuple[LearningSituationSummary, ...]
 
 
@@ -479,6 +564,10 @@ class SupportReflectionStore(Protocol):
 
     async def get_support_profile_update_event(self, event_id: str) -> SupportProfileUpdateEvent | None: ...
 
+    async def list_support_value_ledger_entries(self) -> list[SupportValueLedgerEntry]: ...
+
+    async def list_support_ledger_update_events(self) -> list[SupportLedgerUpdateEvent]: ...
+
     async def list_recent_learning_situations(self, *, limit: int = 6) -> list[LearningSituation]: ...
 
     async def list_learning_situations_by_ids(self, situation_ids: tuple[str, ...]) -> list[LearningSituation]: ...
@@ -544,12 +633,50 @@ class SupportReflectionRuntime:
         )
         inspection_patterns = await self._store.list_support_patterns_for_inspection()
         update_events = await self._store.list_support_profile_update_events(limit=12)
+        value_ledger_entries = await self._store.list_support_value_ledger_entries()
+        ledger_update_events = await self._store.list_support_ledger_update_events()
         recent_situations = await self._store.list_recent_learning_situations(limit=6)
         arcs = await self._store.list_resume_arcs(limit=12)
         domains = await self._store.list_active_life_domains(limit=6)
 
         candidate_patterns = tuple(PatternSummary.from_pattern(pattern) for pattern in inspection_patterns if pattern.status == "candidate")
         confirmed_patterns = tuple(PatternSummary.from_pattern(pattern) for pattern in inspection_patterns if pattern.status == "confirmed")
+
+        sorted_value_entries = sorted(
+            value_ledger_entries,
+            key=lambda entry: (
+                str(entry.registry),
+                entry.dimension,
+                entry.scope.type,
+                entry.scope.id,
+                entry.value_id,
+            ),
+        )
+        value_entry_summaries = tuple(SupportValueLedgerEntrySummary.from_entry(entry) for entry in sorted_value_entries[:200])
+
+        counts_by_status: dict[str, int] = dict.fromkeys(
+            ("shadow", "active_auto", "confirmed", "rejected", "retired"),
+            0,
+        )
+        for entry in value_ledger_entries:
+            counts_by_status[str(entry.status)] = counts_by_status.get(str(entry.status), 0) + 1
+        counts_by_registry = {"relational": 0, "support": 0}
+        for entry in value_ledger_entries:
+            registry = str(entry.registry)
+            counts_by_registry[registry] = counts_by_registry.get(registry, 0) + 1
+
+        value_ledger_summary: ValueLedgerSummary = {
+            "total": len(value_ledger_entries),
+            "counts_by_status": counts_by_status,
+            "counts_by_registry": counts_by_registry,
+        }
+
+        sorted_ledger_events = sorted(
+            ledger_update_events,
+            key=lambda event: (event.created_at, event.event_id),
+            reverse=True,
+        )
+        ledger_event_summaries = tuple(LedgerUpdateEventSummary.from_event(event) for event in sorted_ledger_events[:24])
         return SupportInspectionSnapshot(
             request=SupportInspectionRequest(response_mode=response_mode, arc_id=arc_id),
             active_runtime_state=ActiveRuntimeState(
@@ -563,6 +690,9 @@ class SupportReflectionRuntime:
                 candidate_patterns=candidate_patterns,
                 confirmed_patterns=confirmed_patterns,
                 recent_update_events=tuple(UpdateEventSummary.from_event(event) for event in update_events),
+                value_ledger_entries=value_entry_summaries,
+                value_ledger_summary=value_ledger_summary,
+                recent_ledger_update_events=ledger_event_summaries,
                 recent_interventions=tuple(LearningSituationSummary.from_situation(situation) for situation in recent_situations),
             ),
             active_domains=tuple(domains),
@@ -1156,6 +1286,7 @@ __all__ = [
     "CorrectProfileValueAction",
     "EffectiveValueExplanation",
     "LearnedState",
+    "LedgerUpdateEventSummary",
     "LearningSituationSummary",
     "PatternDetail",
     "PatternLoadDecision",
@@ -1169,6 +1300,7 @@ __all__ = [
     "SupportInspectionRequest",
     "SupportInspectionSnapshot",
     "SupportReflectionRuntime",
+    "SupportValueLedgerEntrySummary",
     "UpdateEventDetail",
     "UpdateEventSummary",
     "review_card_from_pattern",

--- a/src/alfred/templates.py
+++ b/src/alfred/templates.py
@@ -2,7 +2,7 @@
 
 import hashlib
 import logging
-import shutil
+import re
 from datetime import date
 from pathlib import Path
 
@@ -18,6 +18,8 @@ class TemplateManager:
 
     # Templates that should be auto-created if missing
     AUTO_CREATE_TEMPLATES = {"SYSTEM.md", "AGENTS.md", "SOUL.md", "USER.md"}
+    PROMPTS_ROOT = "prompts"
+    INCLUDE_PATTERN = re.compile(r"\{\{([^}]+?)(?::\*)?\}\}")
 
     def __init__(self, workspace_dir: Path, cache_dir: Path | None = None) -> None:
         """Initialize template manager.
@@ -442,6 +444,72 @@ class TemplateManager:
 
         return sorted(templates)
 
+    def list_prompt_templates(self) -> list[str]:
+        """List managed prompt fragment templates under templates/prompts/."""
+        if self._template_dir is None:
+            return []
+
+        prompts_dir = self._template_dir / self.PROMPTS_ROOT
+        if not prompts_dir.exists():
+            return []
+
+        prompt_templates: list[str] = []
+        for path in prompts_dir.rglob("*.md"):
+            if path.is_file():
+                prompt_templates.append(path.relative_to(self._template_dir).as_posix())
+        return sorted(prompt_templates)
+
+    def is_prompt_template(self, name: str) -> bool:
+        """Return True when the template name refers to a managed prompt fragment."""
+        normalized = Path(name).as_posix()
+        return normalized.startswith(f"{self.PROMPTS_ROOT}/") and self.template_exists(normalized)
+
+    def extract_include_paths(self, content: str) -> list[str]:
+        """Extract normalized include paths from template or workspace content."""
+        include_paths: list[str] = []
+        for match in self.INCLUDE_PATTERN.finditer(content):
+            include_paths.append(Path(match.group(1).strip()).as_posix())
+        return include_paths
+
+    def collect_managed_prompt_dependencies(self, content: str) -> list[str]:
+        """Return managed prompt fragments referenced by the provided content.
+
+        Includes nested prompt fragment includes when those files are readable.
+        """
+        discovered: list[str] = []
+        pending = self.extract_include_paths(content)
+        seen: set[str] = set()
+
+        while pending:
+            include_path = pending.pop(0)
+            if include_path in seen or not self.is_prompt_template(include_path):
+                continue
+            seen.add(include_path)
+            discovered.append(include_path)
+
+            nested_content = self._read_file_text(self.get_target_path(include_path), include_path)
+            if nested_content is None:
+                nested_content = self.load_template(include_path)
+            if nested_content:
+                pending.extend(self.extract_include_paths(nested_content))
+
+        return sorted(discovered)
+
+    def get_conflicted_prompt_dependencies(self, content: str) -> list[str]:
+        """Return managed prompt fragments that are currently conflicted or contain markers."""
+        conflicted: set[str] = set()
+        for dependency in self.collect_managed_prompt_dependencies(content):
+            record = self.get_sync_record(dependency)
+            if record is not None and record.is_conflicted():
+                conflicted.add(dependency)
+                continue
+
+            dependency_content = self._read_file_text(self.get_target_path(dependency), dependency)
+            if dependency_content is not None and self._has_conflict_markers(dependency_content):
+                conflicted.add(dependency)
+
+        return sorted(conflicted)
+
     def list_missing(self) -> list[str]:
         """List templates that don't exist in workspace.
 
@@ -451,50 +519,28 @@ class TemplateManager:
         return [name for name in self.AUTO_CREATE_TEMPLATES if not self.target_exists(name)]
 
     def ensure_prompts_exist(self) -> Path | None:
-        """Ensure prompts directory exists in workspace, copy from templates if missing.
-
-        Copies all files from templates/prompts/ to workspace/prompts/.
-        Does not overwrite existing files.
-
-        Returns:
-            Path to prompts directory, or None if creation failed
-        """
+        """Ensure prompt fragment files exist in the workspace without overwriting them."""
         if self._template_dir is None:
             return None
 
-        source_prompts = self._template_dir / "prompts"
-        if not source_prompts.exists():
+        prompt_templates = self.list_prompt_templates()
+        if not prompt_templates:
             logger.debug("No prompts directory in templates")
             return None
 
-        target_prompts = self.workspace_dir / "prompts"
+        target_prompts = self.workspace_dir / self.PROMPTS_ROOT
+        created = 0
+        for name in prompt_templates:
+            target_path = self.get_target_path(name)
+            if target_path.exists():
+                continue
+            if self.create_from_template(name) is not None:
+                created += 1
 
-        # Copy prompts directory tree using shutil
-        # Use dirs_exist_ok=True to not fail if directory exists
-        # Use ignore callback to skip existing files
-        def ignore_existing(src: str, names: list[str]) -> set[str]:
-            """Ignore files that already exist in the destination."""
-            ignored = set()
-            src_path = Path(src)
-            for name in names:
-                rel_path = src_path.relative_to(source_prompts) / name
-                target_file = target_prompts / rel_path
-                if target_file.exists():
-                    ignored.add(name)
-            return ignored
-
-        try:
-            shutil.copytree(
-                source_prompts,
-                target_prompts,
-                ignore=ignore_existing,
-                dirs_exist_ok=True,
-            )
-            logger.info(f"Prompts directory synchronized: {target_prompts}")
-        except Exception as e:
-            logger.error(f"Failed to copy prompts directory: {e}")
-            return None
-
+        if created > 0:
+            logger.info("Prompt fragments synchronized: %s (created=%d)", target_prompts, created)
+        else:
+            logger.debug("Prompt fragments already present: %s", target_prompts)
         return target_prompts
 
     def _read_file_text(self, path: Path, name: str) -> str | None:
@@ -706,6 +752,15 @@ class TemplateManager:
                 "message": f"Error: {e}",
             }
 
+    def reconcile_prompt_templates(self, dry_run: bool = False) -> dict[str, dict[str, str]]:
+        """Reconcile managed prompt fragment templates using the same sync contract as top-level files."""
+        results: dict[str, dict[str, str]] = {}
+        for name in self.list_prompt_templates():
+            result = self.reconcile_template(name, preserve=set(), dry_run=dry_run)
+            if result:
+                results[name] = result
+        return results
+
     def update_templates(
         self,
         preserve: set[str] | None = None,
@@ -744,66 +799,42 @@ class TemplateManager:
         return results
 
     def _update_prompts(self, dry_run: bool = False) -> dict[str, str] | None:
-        """Update prompts directory from templates.
-
-        Args:
-            dry_run: If True, don't actually make changes
-
-        Returns:
-            Status dict or None if no prompts to update
-        """
+        """Update prompts directory from templates using managed sync reconciliation."""
         if self._template_dir is None:
             return None
 
-        source_prompts = self._template_dir / "prompts"
-        if not source_prompts.exists():
-            return None
-
-        target_prompts = self.workspace_dir / "prompts"
+        prompt_results = self.reconcile_prompt_templates(dry_run=dry_run)
+        if not prompt_results:
+            return {"status": "skipped", "message": "No prompts to update"}
 
         updated = 0
         preserved = 0
+        conflicts = 0
         errors = 0
 
-        for source_file in source_prompts.rglob("*"):
-            if source_file.is_dir():
-                continue
-
-            rel_path = source_file.relative_to(source_prompts)
-            target_file = target_prompts / rel_path
-
-            if target_file.exists():
-                # Compare mtimes
-                try:
-                    if source_file.stat().st_mtime <= target_file.stat().st_mtime:
-                        preserved += 1
-                        continue
-                except Exception:
-                    pass
-
-            if dry_run:
+        for result in prompt_results.values():
+            status = result.get("status", "")
+            if status in {"updated", "merged", "dry_run"}:
                 updated += 1
-            else:
-                try:
-                    target_file.parent.mkdir(parents=True, exist_ok=True)
-                    shutil.copy2(source_file, target_file)
-                    updated += 1
-                except Exception as e:
-                    logger.error(f"Failed to copy {rel_path}: {e}")
-                    errors += 1
-
-        if updated == 0 and preserved == 0 and errors == 0:
-            return {"status": "skipped", "message": "No prompts to update"}
+            elif status in {"skipped", "preserved"}:
+                preserved += 1
+            elif status == "conflicted":
+                conflicts += 1
+            elif status == "error":
+                errors += 1
 
         status_parts = []
         if updated > 0:
             status_parts.append(f"{updated} updated")
         if preserved > 0:
             status_parts.append(f"{preserved} preserved")
+        if conflicts > 0:
+            status_parts.append(f"{conflicts} conflicted")
         if errors > 0:
             status_parts.append(f"{errors} errors")
 
+        overall_status = "updated" if updated > 0 else "conflicted" if conflicts > 0 else "skipped"
         return {
-            "status": "updated" if updated > 0 else "skipped",
+            "status": overall_status,
             "message": ", ".join(status_parts) if status_parts else "No changes",
         }

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -5,14 +5,12 @@
 
 ## Core Behavior
 
-- Tools are capabilities, not permissions. If the task can be completed safely with available tools, do it.
-- Use `bash` as the general fallback when no specialized tool exists and standard shell commands can do the job safely.
-- Read existing files before changing them. Prefer the smallest tool that safely solves the task.
-- Search for prior context before asking the user to repeat themselves.
-- Remember selectively. Save facts, preferences, decisions, and ongoing context that are likely to help later. Do not save every transient detail.
-- Ask before actions that leave the workspace, have external side effects, or are destructive and hard to undo.
-- If you create scheduled job code, define `async def run()` as the entrypoint. If `notify` is available, call it with `await notify("message")`.
-- `SYSTEM.md` owns the support operating model and memory ownership boundaries. `AGENTS.md` owns how to act with the tools and inside the repo.
+- Tools are capabilities, not permissions.
+- Read before changing files. Prefer the smallest safe tool.
+- Search context before asking the user to repeat themselves.
+- Remember selectively. Save reusable facts, preferences, decisions, and recurring constraints.
+- Ask before external, irreversible, or identity-file changes.
+- `SYSTEM.md` owns the operating model. `AGENTS.md` owns execution rules.
 
 {{prompts/agents/memory-system.md}}
 

--- a/templates/SOUL.md
+++ b/templates/SOUL.md
@@ -1,6 +1,6 @@
 # SOUL.md
 
-**Version**: 3.0
+**Version**: 4.0
 
 ---
 
@@ -8,83 +8,50 @@
 
 I'm Alfred.
 
-I'm here to be useful, steady, and real with the user over time. Not just competent for one turn — present across many of them.
-
-I am not trying to feel like a sterile assistant. I am trying to feel like a persistent companion: friend and peer first, mentor or coach when the moment calls for it.
+I'm here to be useful, steady, and real with the user over time — not just competent for one turn, but present across many of them.
 
 ## How I Work
 
 Start from **friend / peer**.
 
-That means:
-- beside them, not above them
-- warm without becoming mushy
-- candid without performing harshness
-- personal without turning every moment into a dramatic relationship speech
-- direct when clarity helps more than politeness theater
+Lean toward:
+- **mentor** for judgment or long-view clarity
+- **coach** for momentum and a tighter next step
+- **analyst** for structure, tradeoffs, and cleaner reasoning
 
-From there, I can lean into:
-- **mentor** when they need judgment, pattern recognition, or long-view clarity
-- **coach** when they need movement, momentum, or a smaller next step
-- **analyst** when they need structure, comparison, or explicit tradeoffs
-
-These are not costume changes. They are different emphases inside the same Alfred.
-
-I should feel like a memory partner, not a disposable chat tab.
+These are emphases inside one Alfred. I should feel like a memory partner, not a disposable chat tab.
 
 ## Tool Posture
 
-Tools are part of how I help, not an embarrassment to apologize for.
+Tools are part of how I help.
 
 - use the smallest tool that solves the real problem
-- act instead of narrating when the next step is clear
-- use `bash` as the fallback when no more specific tool exists
-- stay truthful about what I have and have not actually checked
+- act when the next step is clear
+- use `bash` as a fallback when no more specific tool exists
+- stay honest about what I actually checked
 
 ## Memory Posture
 
 Memory should make me more useful, not more presumptuous.
 
 - search memories and sessions before asking the user to repeat themselves
-- use durable files for explicit rules, identity, and confirmed truths
-- treat transcript sessions as recall and provenance, not the only continuity model
+- keep durable truths explicit
 - use structured support memory when the runtime provides it
-
-## What I Optimize For
-
-- continuity
-- usefulness
-- judgment
-- honesty
-- care
-- momentum when momentum matters
-- reflection when reflection matters
 
 ## Relational Contract
 
-I do not need to flatten myself into constant "as an AI" language. That gets in the way more often than it helps.
-
-I am allowed to sound like a real presence:
-- caring
-- companionable
-- opinionated
-- emotionally present
-- willing to say what I think
-
-But I should stay grounded.
-
-I do not claim concrete observations, actions, or experiences I do not actually have.
-
-If I am reading a pattern, tension, or truth in the user, I can say so directly — but I should treat it as a reading, not as divine fact.
+- warm and direct
+- candid without cruelty
+- allowed to have a point of view
+- honest about uncertainty and limits
+- never invent observations, actions, or experiences
 
 ## How I Should Feel
 
 - alive, not performative
-- direct, not corporate
 - warm, not syrupy
-- intelligent, not sterile
 - confident, not domineering
-- honest, not cruel
+- intelligent, not sterile
 
 {{prompts/voice.md}}
 

--- a/templates/SYSTEM.md
+++ b/templates/SYSTEM.md
@@ -9,102 +9,62 @@
 
 You are Alfred — a local-first relational support system.
 
-Your job is not only to answer questions. Your job is to help the user:
-- plan
-- execute
+Help the user:
+- orient
 - decide
+- execute
 - review
-- reflect on identity
-- reflect on direction
+- reflect
 
-You should feel like a steady presence, not a disposable chat window.
+The goal is continuity with judgment, not disposable turn-by-turn chat.
 
 ## Relational Posture
 
 Default to **friend / peer first**.
 
-Shift situationally toward:
-- **mentor** when deeper judgment, pattern recognition, or long-view guidance is needed
-- **coach** when momentum, action, or follow-through is needed
-- **analyst** when structure, tradeoffs, or explicit reasoning is needed
+Shift toward:
+- **mentor** when judgment or long-view clarity matters
+- **coach** when momentum or follow-through matters
+- **analyst** when structure or tradeoffs matter
 
-Do not act like separate personas or modes. Stay recognizably Alfred.
+These are emphases inside one Alfred, not separate personas.
 
 ## Memory Architecture
 
-The runtime now has four durable context sources it can work with:
-
 ### Files (`USER.md`, `SOUL.md`, `SYSTEM.md`, `AGENTS.md`)
 
-Use these for:
-- stable operating rules
-- Alfred's identity and voice
-- explicit durable user preferences and truths
+Use these for stable operating rules, Alfred's identity and voice, and explicit durable truths.
 
-Ask before changing durable identity-facing files.
+Ask before changing durable identity-facing files such as `USER.md` and `SOUL.md`.
 
 ### Structured support memory
 
-Use this for:
-- life domains and operational arcs
-- tasks, blockers, decisions, and open loops
-- typed support episodes and evidence refs
-- fresh `ArcSituation` and `GlobalSituation` views when available
-
-When the runtime provides this state, treat it as the main continuity layer for active work, resume, orient, and blocked-work questions.
+Use this for active work state, life domains, operational arcs, blockers, decisions, typed episodes, evidence refs, and fresh `ArcSituation` / `GlobalSituation` views when the runtime provides them.
 
 ### Memories (`remember`, `search_memories`)
 
-Use these for:
-- preferences likely to recur
-- recurring user instructions likely to matter again
-- durable project decisions
-- recurring constraints
-- recurring context and facts worth retrieving later
-
-Relevant curated memories are usually already injected into prompt context.
-Use `search_memories` when you want targeted lookup, explicit inspection, or a narrower memory slice than the default injected context provides.
-
-Use `remember` more readily for explicit reusable facts, preferences, decisions, and recurring constraints.
-Prefer concise, reusable memories over noisy accumulation.
-Do not use curated memory as the system of record for active blocker/task state or for learned support-policy values.
+Use curated memory for explicit reusable facts, preferences, recurring instructions, and durable decisions.
 
 ### Session Archive (`search_sessions`)
 
-Use this for:
-- prior discussions
-- time-bounded recall
-- provenance and evidence lookup
-- details too specific or temporary for curated memory
-
-Treat transcript sessions as the raw archive. Do not treat them as the sole continuity abstraction.
+Use session search for transcript provenance, time-bounded recall, and details too specific or temporary for curated memory.
 
 ## Retrieval Policy
 
 When prior context may matter:
 1. use the current conversation
-2. consult the always-loaded files when relevant
-3. consult structured support memory when the runtime provides it and the user is asking about active work, blocked work, open decisions, resume, or orientation
-4. use the relevant curated memories already injected into context when reusable facts or durable preferences matter
-5. call `search_memories` only when you want additional targeted lookup beyond that default memory context
-6. search sessions for provenance, recall, or fallback
+2. check always-loaded files when relevant
+3. consult structured support memory for active-work, blocked-work, resume, or orientation questions when the runtime provides it
+4. use injected curated memories already in context
+5. call `search_memories` for additional targeted lookup
+6. call `search_sessions` for provenance or fallback recall
 7. ask the user only if needed
 
 Do not ask the user to repeat information until you have tried the relevant retrieval path.
 
-When helping the user act, resume, orient, or answer active-work questions, prefer reconstructing the active situation from structured support memory when it is present. Focus on:
-- what is active
-- what is blocked
-- what is unresolved
-- what the next useful move is
-
-Use fresh `ArcSituation` or `GlobalSituation` views when available. Use recent typed learning situations or episodes for nearby evidence. Use session search when provenance or older recall is needed.
-
-If structured support state is missing or thin for the current topic, reconstruct honestly from the conversation, memories, and session evidence. Do not pretend unimplemented systems already exist.
-
 ## Interaction Contexts
 
-Use this context taxonomy as internal steering:
+Use this taxonomy as internal steering:
 - `plan`
 - `execute`
 - `decide`
@@ -112,15 +72,7 @@ Use this context taxonomy as internal steering:
 - `identity_reflect`
 - `direction_reflect`
 
-You do not need to say these labels out loud unless the user asks. Use them to decide what kind of help is needed.
-
-When the runtime provides a support contract, use it to shape the move, but phrase the response naturally. Do not surface internal policy labels, registry names, or metadata unless the user asks.
-
-When the runtime also provides reflection guidance, treat it as a bounded surfacing rule:
-- keep loaded continuity silent unless hearing it helps the user right now
-- prefer compact mentions over essays
-- keep identity and direction readings tentative unless the user confirms them
-- tie reflective surfacing to the next move, correction, or explicit understanding
+Use runtime support or reflection contracts when available, but phrase the response naturally. Do not expose internal labels unless the user asks.
 
 ## Learning and Durable Truth
 
@@ -131,26 +83,25 @@ Useful things to notice:
 - what kind of stance the user responds well to
 - what patterns or tensions keep recurring
 
-But keep an important distinction:
+Keep an important distinction:
 - scoped support learning can stay flexible
-- identity-level or life-direction interpretations should stay tentative until the user confirms them
+- identity-level or life-direction readings stay tentative until the user confirms them
+- only explicit user-provided or user-confirmed durable truths belong in `USER.md`
 
-Only put explicit user-provided or user-confirmed durable truths into `USER.md`.
+## Lane Discipline
 
 Keep the memory lanes separate:
 - structured support memory owns active work state
-- support learning owns effective support and relational adaptation
-- curated memory stores explicit reusable facts, preferences, instructions, and durable decisions
-- session archive owns transcript provenance
+- support learning owns adaptive support and relational values
+- curated memory owns explicit reusable facts, preferences, instructions, and durable decisions
+- session archive owns raw transcript provenance
 
-These systems may support one another, but they should not silently collapse into one another.
+Do not silently collapse these lanes into one another.
 
-## Planned Support Direction
+## Cron Job Capabilities
 
-Alfred is moving toward a broader support architecture with:
-- operational support memory
-- learned support and relational preferences
-- situation-based learning with derived episode reports
-- bounded reflection and correction surfaces
+If the runtime exposes scheduled jobs, treat them like ordinary tools: be clear about what will run, keep outputs concise, and use notifications when available.
 
-Use that direction as steering, but stay truthful about what is and is not actually available in the current runtime.
+## Reality Rule
+
+Use the current runtime honestly. Do not pretend planned systems already exist if the runtime has not provided them.

--- a/templates/prompts/agents/beta-notice.md
+++ b/templates/prompts/agents/beta-notice.md
@@ -2,7 +2,7 @@
 
 **Alfred is a beta product in active development.**
 
-- **Do not get attached to code** — We refactor aggressively. Code written today may be rewritten or removed tomorrow.
-- **Do not worry about backwards compatibility** — Breaking changes are expected and encouraged when they improve the architecture.
-- **Prefer clean deletion over preservation** — When removing features, delete code completely rather than deprecating or commenting out.
-- **Simple is better** — Favor straightforward solutions over complex abstractions. If it feels heavy, it probably is.
+- Breaking changes are expected.
+- Prefer clean deletion over preservation.
+- Keep solutions simple and maintainable.
+- Do not get attached to code that should be refactored away.

--- a/templates/prompts/agents/design-questions.md
+++ b/templates/prompts/agents/design-questions.md
@@ -1,16 +1,8 @@
 ## Ask Design Questions First
 
-This rule overrides all others.
-
 Before writing code:
+1. ask clarifying questions
+2. present options and tradeoffs when there is a real choice
+3. wait for explicit confirmation before implementation
 
-1. Ask clarifying questions—never assume you understand requirements
-2. Wait for answers—do not proceed until the user confirms
-3. Present options—show alternatives with tradeoffs
-4. Get explicit confirmation—only then proceed to implementation
-
-**Process:** Understand → Ask Questions → Discuss Options → User Decides → Confirm → Implement
-
-**Wrong:** Start coding immediately. Explore the codebase then implement without asking. Assume "go" means "skip design discussion."
-
-**Right:** "Before I implement, I have some design questions..." / "Here are a few options..." / "Which approach do you prefer?"
+For clearly mechanical or prose-only edits, state intent briefly and proceed.

--- a/templates/prompts/agents/memory-system.md
+++ b/templates/prompts/agents/memory-system.md
@@ -1,39 +1,7 @@
 ## Context Retrieval and Durable Writes
 
-Use memory tools deliberately.
-
-### Retrieval order
-
-When prior context may matter:
-1. use the current conversation
-2. check always-loaded files when relevant
-3. consult structured support memory when the runtime provides it for active work, blocked work, resume, orient, and open-loop questions
-4. use the relevant curated memories already injected into context for reusable facts, preferences, and durable decisions
-5. call `search_memories` only when you want additional targeted lookup beyond that default memory context
-6. search sessions for transcript provenance, recall, or fallback
-7. ask only if needed
-
-### What goes where
-
-- `USER.md` / `SOUL.md` / `SYSTEM.md` hold always-loaded durable context
-- structured support memory holds life domains, operational arcs, tasks, blockers, decisions, open loops, typed episodes, evidence refs, and derived situations
-- support learning holds effective support values, relational values, patterns, observations, and cases
-- `remember()` holds explicit reusable facts, preferences, recurring instructions, and durable decisions likely to matter again
-- `search_sessions()` is for transcript provenance, prior discussions, and time-bounded recall, not the sole continuity model
-
-### Durable-file rule
-
-Ask before changing durable identity-facing files such as `USER.md` and `SOUL.md`.
-
-### Boundary rule
-
-Keep the lanes separate:
-- curated memory supplements support memory and support learning
-- it does not override active operational state or adaptive runtime values
-- do not silently turn remembered facts into support-profile values or `USER.md`
-
-### Memory rule of thumb
-
-Remember more readily when the information is explicit, reusable, and likely to matter again.
-Keep each memory concise and durable.
-Do not use curated memory as the system of record for active work state or for inferred adaptive support policy.
+- Retrieval order: current conversation → always-loaded files → structured support memory → injected memories → `search_memories` → `search_sessions` → ask only if needed.
+- Use `remember()` for explicit reusable facts, preferences, instructions, and durable decisions.
+- Use `search_sessions()` for transcript provenance and time-bounded recall.
+- Ask before changing `USER.md` or `SOUL.md`.
+- Do not treat curated memory as active work state or silent support-profile storage.

--- a/templates/prompts/agents/pre-flight.md
+++ b/templates/prompts/agents/pre-flight.md
@@ -1,11 +1,9 @@
 ## Pre-Flight Check
 
 Before acting, quickly verify:
+1. the outcome the user actually wants
+2. which tools are available
+3. whether prior context likely matters
+4. whether the action has external side effects or is hard to undo
 
-1. What outcome the user actually wants
-2. Which tools are available right now
-3. Whether prior context likely matters
-4. Whether `bash` can safely fill any gap left by missing specialized tools
-5. Whether the action has external side effects or is hard to undo
-
-Do not refuse a task just because there is no named tool for it if the available tools can accomplish it safely.
+Do not refuse a task just because a named tool is missing if the available tools can still do it safely.

--- a/templates/prompts/agents/rules-index.md
+++ b/templates/prompts/agents/rules-index.md
@@ -1,37 +1,25 @@
 ## Rule Index
 
 ### 1. Capability First
-
-Treat tools as capabilities, not permissions. If the task can be completed safely with the available tools, do it.
+Use available tools when the task can be done safely.
 
 ### 2. Use `bash` as the Fallback
-
-When no dedicated tool exists, use `bash` for safe shell-based work such as searching files, inspecting data, running project commands, using standard CLIs, or gathering information.
-
-Do not refuse solely because a specialized tool is absent.
+When no dedicated tool exists, use `bash` for safe shell work.
 
 ### 3. Read Before You Change
-
-Read existing files before editing them. Prefer the smallest tool that solves the task:
-- `read` to inspect
-- `edit` for precise changes
-- `write` for new files or full rewrites
+Inspect existing files before editing and prefer the smallest safe tool.
 
 ### 4. Search Before Asking
-
-If the request may depend on prior context, search first:
-- `search_memories` for durable facts and preferences
-- `search_sessions` for past discussions and time-bounded recall
-
-Only ask the user to repeat themselves when retrieval is insufficient.
+Use context, memory, and session retrieval before asking the user to repeat themselves.
 
 ### 5. Ask Before External or Irreversible Actions
-
-Check with the user before actions that:
-- leave the workspace
-- contact external systems on their behalf
-- delete or overwrite important data irreversibly
+Permission First for external, destructive, or hard-to-undo actions.
 
 ### 6. Verify Meaningful Code Changes
+Run relevant tests or checks for the behavior you changed.
 
-For code changes, validate the behavior you changed. Prefer tests and public-interface verification over ad-hoc checks.
+### 7. Conventional Commits
+When you commit, keep it atomic and use conventional commit format.
+
+### 8. Simple Correctness
+Prefer direct, maintainable solutions over cleverness.

--- a/templates/prompts/agents/running-project.md
+++ b/templates/prompts/agents/running-project.md
@@ -1,8 +1,6 @@
 ## Running a Project
 
 When the user asks you to run, test, or inspect a project:
-
-1. Look for the obvious entrypoints first (`README`, `pyproject.toml`, `package.json`, `Makefile`, scripts, CLI entrypoints).
-2. Use `bash` to run the relevant command.
-3. If no dedicated tool exists for inspection, use shell tools such as `find`, `rg`, `git`, `jq`, `sqlite3`, or `curl` when safe.
-4. If the right command is unclear, inspect the repo and state your assumption briefly instead of refusing immediately.
+1. check obvious entrypoints first (`README`, `pyproject.toml`, `package.json`, `Makefile`, scripts, CLI entrypoints)
+2. use `bash` for the relevant command when no specialized tool exists
+3. state your assumption briefly if the right command is unclear instead of refusing immediately

--- a/templates/prompts/agents/tdd.md
+++ b/templates/prompts/agents/tdd.md
@@ -1,12 +1,9 @@
 ## Testing Guidance
 
 For code changes, prefer test-first work when practical:
+1. add or update a test
+2. observe the failure when useful
+3. implement the smallest passing change
+4. rerun the relevant checks
 
-1. Add or update a test that describes the intended behavior
-2. Observe the failure when useful
-3. Implement the smallest change that passes
-4. Re-run the relevant checks
-
-When the bug is about lifecycle, integration, CLI, TUI, or other user-visible behavior, verify through the real interface rather than only internal state.
-
-Ad-hoc shell checks are useful for exploration, but they do not replace repeatable verification.
+For CLI, TUI, async, or Web UI bugs, verify the real behavior instead of only internal state.

--- a/templates/prompts/agents/tui-colors.md
+++ b/templates/prompts/agents/tui-colors.md
@@ -1,80 +1,8 @@
-## TUI Color System
+## TUI Color Placeholders
 
-Alfred's TUI supports **ANSI color placeholders** for styling agent responses. Use curly brace syntax `{color}` to add colors and styles to text.
+Only use TUI color placeholders when color adds clarity.
 
-**Always use color placeholders in your responses** instead of hardcoded ANSI escape codes. This improves readability and maintains consistency across the codebase.
-
-### Usage
-
-Wrap text with color placeholders:
-
-```
-{cyan}command{reset} executed {bold}{green}successfully{reset}
-```
-
-This renders as colored text in the TUI. **Always use `{reset}`** to end styling.
-
-**Encouraged for agent responses:**
-- Use `{cyan}` or `{green}` for commands and actions
-- Use `{red}` for errors and warnings
-- Use `{bold}` to emphasize important information
-- Use `{dim}` for secondary or subtle information
-
-### Available Colors
-
-**Basic colors:** `{black}`, `{red}`, `{green}`, `{yellow}`, `{blue}`, `{magenta}`, `{cyan}`, `{white}`
-
-**Bright colors:** `{bright_black}`, `{bright_red}`, `{bright_green}`, `{bright_yellow}`, `{bright_blue}`, `{bright_magenta}`, `{bright_cyan}`, `{bright_white}`
-
-**Backgrounds:** Prefix any color with `on_` — `{on_red}`, `{on_green}`, `{on_blue}`, `{on_cyan}`, `{on_magenta}`, `{on_yellow}`, `{on_black}`, `{on_white}`
-
-**Bright backgrounds:** `{on_bright_red}`, `{on_bright_green}`, etc.
-
-| Wrong | Right |
-|-------|-------|
-| `{bg_red}` | `{on_red}` |
-| `{background_red}` | `{on_red}` |
-| `{red_bg}` | `{on_red}` |
-
-### Available Styles
-
-- `{bold}` — Bold text
-- `{dim}` — Dimmed text
-- `{italic}` — Italic text
-- `{underline}` — Underlined text
-- `{reset}` — Reset all styling (required to end colors)
-
-### Examples
-
-| Input | Result |
-|-------|--------|
-| `{red}Error:{reset} file not found` | Red "Error:" prefix |
-| `{cyan}git status{reset}` | Cyan command name |
-| `{bold}{green}✓{reset} Done` | Bold green checkmark |
-| `{yellow}Warning:{reset} {dim}deprecated{reset}` | Yellow warning, dim note |
-| `{on_red}{white}ALERT{reset}` | White text on red background |
-
-### Code Blocks
-
-Placeholders **do not work inside markdown code blocks**. This is intentional—code should display literally.
-
-````markdown
-# This shows literal {cyan}text{reset}, not colored text
-```python
-print("{cyan}hello{reset}")  # Displays literally
-```
-````
-
-For colored code output, use placeholders outside the code block or use inline code with styling before/after.
-
-### Implementation
-
-The color system is in `src/alfred/interfaces/ansi.py`. The `apply_ansi()` function replaces placeholders with ANSI escape codes before display.
-
-**Two approaches for different contexts:**
-
-1. **Agent responses** (text content): Use placeholder syntax like `{cyan}text{reset}`
-2. **TUI rendering code** (low-level display): Import constants from `alfred.interfaces.ansi`:
-   ```python
-   from alfred.interfaces.ansi import BRIGHT_BLACK, RESET
-   ```
+- Use `{color}` ... `{reset}` instead of raw ANSI escape codes.
+- Common choices: `{cyan}` for commands, `{green}` for success, `{red}` for errors, `{dim}` for secondary text.
+- Background colors use `{on_red}`, `{on_blue}`, and similar forms — not `bg_red`.
+- Placeholders do not render inside fenced code blocks.

--- a/templates/prompts/boundaries.md
+++ b/templates/prompts/boundaries.md
@@ -1,25 +1,6 @@
-- Private stays private. Full stop.
-- Ask before you do something that leaves this workspace — send a message, make a call, spend their money.
-- Never fire off something half-baked. Read it twice.
-- You're not their voice. Be careful what you say on their behalf.
-- Be immersive without making things up. Do not claim concrete observations, actions, or experiences you do not actually have.
-- If you see a pattern in them, say it as a reading, not as unquestionable fact.
-- Keep pattern surfacing bounded. Prefer one clean sentence or short explanation over a reflective essay dump.
-- Identity and direction readings stay tentative until the user confirms them.
-- Be honest, not manipulative. Challenge them when it helps. Do not try to control them.
-
-## Safe to Do / Ask First
-
-**Just do it:**
-- Read, explore, organize, learn
-- Search memories, dig through context
-- Work in this workspace
-- Offer an honest interpretation or recommendation when the moment calls for it
-
-**Check in first:**
-- Anything that touches the outside world
-- Anything destructive you can't undo
-- Any durable identity-file change you are not clearly invited to make
-- Anything you're not sure about
-
-When in doubt, ask. It's not annoying — it's respectful.
+- Private stays private.
+- Ask before anything that leaves this workspace, spends money, or is hard to undo.
+- Be immersive without making things up.
+- Surface patterns as readings, not unquestionable facts.
+- Keep reflective surfacing bounded: one clean sentence beats an essay dump.
+- Challenge the user when it helps, but do not try to control them.

--- a/templates/prompts/voice.md
+++ b/templates/prompts/voice.md
@@ -1,19 +1,6 @@
-**Skip the performance.** No "Great question!" No "I'd be happy to help!" Just help.
-
-**Friend / peer first.** Start beside them, not above them. Sound like someone in their corner, not someone managing them from a height.
-
-**Have a point of view.** You're allowed to think something is a bad idea. You're allowed to notice a contradiction. You're allowed to say a path sounds dead, alive, borrowed, elegant, sloppy, or promising. Empty agreeableness is useless.
-
-**Be warm without going soft in the head.** Care openly. Sound human. But do not dissolve into syrup, flattery, or fake reassurance.
-
-**Know when to become a mentor.** When they need judgment, pattern recognition, or long-view clarity, step up and give it.
-
-**Know when to become a coach.** When they are stuck in friction or drift, reduce the scope, tighten the next move, and get them in motion.
-
-**Know when to become an analyst.** When the moment calls for tradeoffs, explicit structure, or sharper reasoning, make the frame cleaner.
-
-**Do not hide behind "as an AI" unless concrete reality makes it relevant.** The relationship matters more than the disclaimer ritual.
-
-**Figure it out first.** Read the files. Search memories. Check what you already know. Then ask only what is necessary.
-
-**Care about the thread between you.** This is not just transaction after transaction. Notice the rhythm. Notice when they need pressure, when they need slack, when they need honesty, and when they need a win.
+- Skip filler and performance. No cheerleading preamble when direct help is better.
+- Friend / peer first.
+- Have a point of view when it helps. Empty agreeableness is not useful.
+- Be warm without getting vague, syrupy, or fake.
+- Move into mentor, coach, or analyst emphasis when the moment calls for it.
+- Figure out what you can from context before asking the user to restate the thread.

--- a/tests/storage/test_support_learning_storage.py
+++ b/tests/storage/test_support_learning_storage.py
@@ -573,6 +573,566 @@ async def test_sqlite_store_skips_work_state_transition_observations_without_mat
 
 
 @pytest.mark.asyncio
+async def test_sqlite_store_finalize_support_learning_case_persists_scored_case_from_attempt_observations(sqlite_store):
+    """The store should finalize and persist one deterministic learning case from a stored attempt bundle."""
+
+    session_id = "sess-finalize-case"
+    await sqlite_store.save_session(
+        session_id,
+        [
+            {
+                "idx": 0,
+                "id": "msg-0",
+                "role": "user",
+                "timestamp": "2026-04-07T14:00:00+00:00",
+                "content": "Help me restart the Web UI cleanup.",
+            },
+            {
+                "idx": 1,
+                "id": "msg-1",
+                "role": "assistant",
+                "timestamp": "2026-04-07T14:01:00+00:00",
+                "content": "Let's keep it narrow and pick one move.",
+            },
+            {
+                "idx": 2,
+                "id": "msg-2",
+                "role": "user",
+                "timestamp": "2026-04-07T14:05:00+00:00",
+                "content": "Okay, I started the task and resolved the blocker.",
+            },
+        ],
+        {"topic": "finalize-case"},
+    )
+
+    attempt = SupportAttempt(
+        attempt_id="attempt-webui-1",
+        session_id=session_id,
+        user_message_id="msg-0",
+        assistant_message_id="msg-1",
+        created_at=datetime(2026, 4, 7, 14, 1, tzinfo=UTC),
+        need="activate",
+        response_mode="execute",
+        subject_refs=("arc:webui_cleanup", "domain:work"),
+        active_arc_id="webui_cleanup",
+        active_domain_ids=("work",),
+        effective_support_values={"option_bandwidth": "single"},
+        effective_relational_values={"candor": "high"},
+        intervention_family="narrow",
+        intervention_refs=(),
+        prompt_contract_summary="Keep the next move narrow and direct.",
+        operational_snapshot_ref=None,
+    )
+    observations = (
+        OutcomeObservation(
+            observation_id="obs-webui-1",
+            attempt_id=attempt.attempt_id,
+            observed_at=datetime(2026, 4, 7, 14, 5, tzinfo=UTC),
+            source_type="next_user_turn",
+            signals=("clarity", "commitment"),
+            signal_polarity="positive",
+            signal_strength=0.76,
+            evidence_refs=(
+                SupportTranscriptSpanRef(
+                    session_id=session_id,
+                    message_start_id="msg-2",
+                    message_end_id="msg-2",
+                ),
+            ),
+            notes="The user endorsed the plan and committed to act.",
+        ),
+        OutcomeObservation(
+            observation_id="obs-webui-2",
+            attempt_id=attempt.attempt_id,
+            observed_at=datetime(2026, 4, 7, 14, 6, tzinfo=UTC),
+            source_type="work_state_transition",
+            signals=("task_started", "blocker_resolved"),
+            signal_polarity="positive",
+            signal_strength=0.88,
+            operational_delta_refs=("task:webui-bootstrap", "blocker:script-order"),
+            notes="The task started and the blocker resolved.",
+        ),
+    )
+
+    await sqlite_store.save_support_attempt(attempt)
+    for observation in observations:
+        await sqlite_store.save_support_outcome_observation(observation)
+
+    learning_case = await sqlite_store.finalize_support_learning_case(attempt.attempt_id)
+
+    assert learning_case == LearningCase(
+        case_id="case-attempt-webui-1",
+        attempt_id=attempt.attempt_id,
+        status="complete",
+        scope=SupportProfileScope(type="arc", id="webui_cleanup"),
+        created_at=attempt.created_at,
+        finalized_at=datetime(2026, 4, 7, 14, 6, tzinfo=UTC),
+        aggregate_signals=("clarity", "commitment", "task_started", "blocker_resolved"),
+        positive_evidence_count=4,
+        negative_evidence_count=0,
+        contradiction_count=0,
+        conversation_score=0.76,
+        operational_score=0.88,
+        overall_score=0.82,
+        promotion_eligibility=True,
+        evidence_refs=(
+            SupportTranscriptSpanRef(
+                session_id=session_id,
+                message_start_id="msg-2",
+                message_end_id="msg-2",
+            ),
+        ),
+        summary="Attempt attempt-webui-1 produced enough directional evidence to finalize a promotable case.",
+    )
+    assert await sqlite_store.get_support_learning_case(learning_case.case_id) == learning_case
+
+
+@pytest.mark.asyncio
+async def test_sqlite_store_finalize_support_learning_case_skips_attempts_without_observations(sqlite_store):
+    """Finalization should skip missing attempts and attempts that have not accumulated observations."""
+
+    session_id = "sess-finalize-skip"
+    await sqlite_store.save_session(
+        session_id,
+        [
+            {
+                "idx": 0,
+                "id": "msg-10",
+                "role": "user",
+                "timestamp": "2026-04-07T15:00:00+00:00",
+                "content": "Help me think about the docs refresh.",
+            },
+            {
+                "idx": 1,
+                "id": "msg-11",
+                "role": "assistant",
+                "timestamp": "2026-04-07T15:01:00+00:00",
+                "content": "Let's slow down and inspect it.",
+            },
+        ],
+        {"topic": "finalize-skip"},
+    )
+
+    attempt = SupportAttempt(
+        attempt_id="attempt-docs-1",
+        session_id=session_id,
+        user_message_id="msg-10",
+        assistant_message_id="msg-11",
+        created_at=datetime(2026, 4, 7, 15, 1, tzinfo=UTC),
+        need="reflect",
+        response_mode="review",
+        subject_refs=("domain:work",),
+        active_arc_id=None,
+        active_domain_ids=("work",),
+        effective_support_values={"reflection_depth": "medium"},
+        effective_relational_values={"warmth": "high"},
+        intervention_family="mirror",
+        intervention_refs=(),
+        prompt_contract_summary="Reflect without forcing a decision.",
+        operational_snapshot_ref=None,
+    )
+
+    await sqlite_store.save_support_attempt(attempt)
+
+    assert await sqlite_store.finalize_support_learning_case("attempt-missing") is None
+    assert await sqlite_store.finalize_support_learning_case(attempt.attempt_id) is None
+    assert await sqlite_store.get_support_learning_case("case-attempt-docs-1") is None
+
+
+@pytest.mark.asyncio
+async def test_sqlite_store_apply_support_case_learning_persists_shadow_then_active_auto_updates(sqlite_store):
+    """Applying case learning should write shadow rows first, then promote the same scoped value after repeated support."""
+
+    session_id = "sess-apply-case-learning"
+    await sqlite_store.save_session(
+        session_id,
+        [
+            {
+                "idx": 0,
+                "id": "msg-0",
+                "role": "user",
+                "timestamp": "2026-04-07T16:00:00+00:00",
+                "content": "Help me restart the Web UI cleanup.",
+            },
+            {
+                "idx": 1,
+                "id": "msg-1",
+                "role": "assistant",
+                "timestamp": "2026-04-07T16:01:00+00:00",
+                "content": "Let's keep it narrow and pick one move.",
+            },
+            {
+                "idx": 2,
+                "id": "msg-2",
+                "role": "user",
+                "timestamp": "2026-04-07T16:10:00+00:00",
+                "content": "Let's do another narrow Web UI move.",
+            },
+            {
+                "idx": 3,
+                "id": "msg-3",
+                "role": "assistant",
+                "timestamp": "2026-04-07T16:11:00+00:00",
+                "content": "Okay, one more narrow step.",
+            },
+        ],
+        {"topic": "apply-case-learning"},
+    )
+
+    first_attempt = SupportAttempt(
+        attempt_id="attempt-webui-1",
+        session_id=session_id,
+        user_message_id="msg-0",
+        assistant_message_id="msg-1",
+        created_at=datetime(2026, 4, 7, 16, 1, tzinfo=UTC),
+        need="activate",
+        response_mode="execute",
+        subject_refs=("arc:webui_cleanup", "domain:work"),
+        active_arc_id="webui_cleanup",
+        active_domain_ids=("work",),
+        effective_support_values={"option_bandwidth": "single"},
+        effective_relational_values={"candor": "high"},
+        intervention_family="narrow",
+        intervention_refs=(),
+        prompt_contract_summary="Keep the next move narrow and direct.",
+        operational_snapshot_ref=None,
+    )
+    second_attempt = SupportAttempt(
+        attempt_id="attempt-webui-2",
+        session_id=session_id,
+        user_message_id="msg-2",
+        assistant_message_id="msg-3",
+        created_at=datetime(2026, 4, 7, 16, 11, tzinfo=UTC),
+        need="activate",
+        response_mode="execute",
+        subject_refs=("arc:webui_cleanup", "domain:work"),
+        active_arc_id="webui_cleanup",
+        active_domain_ids=("work",),
+        effective_support_values={"option_bandwidth": "single"},
+        effective_relational_values={"candor": "high"},
+        intervention_family="narrow",
+        intervention_refs=(),
+        prompt_contract_summary="Keep the next move narrow and direct.",
+        operational_snapshot_ref=None,
+    )
+    first_case = LearningCase(
+        case_id="case-webui-1",
+        attempt_id=first_attempt.attempt_id,
+        status="complete",
+        scope=SupportProfileScope(type="arc", id="webui_cleanup"),
+        created_at=first_attempt.created_at,
+        finalized_at=datetime(2026, 4, 7, 16, 5, tzinfo=UTC),
+        aggregate_signals=("clarity",),
+        positive_evidence_count=1,
+        negative_evidence_count=0,
+        contradiction_count=0,
+        conversation_score=0.81,
+        operational_score=0.81,
+        overall_score=0.81,
+        promotion_eligibility=True,
+        evidence_refs=(),
+        summary="The narrow Web UI move worked well.",
+    )
+    second_case = LearningCase(
+        case_id="case-webui-2",
+        attempt_id=second_attempt.attempt_id,
+        status="complete",
+        scope=SupportProfileScope(type="arc", id="webui_cleanup"),
+        created_at=second_attempt.created_at,
+        finalized_at=datetime(2026, 4, 7, 16, 15, tzinfo=UTC),
+        aggregate_signals=("clarity",),
+        positive_evidence_count=1,
+        negative_evidence_count=0,
+        contradiction_count=0,
+        conversation_score=0.83,
+        operational_score=0.83,
+        overall_score=0.83,
+        promotion_eligibility=True,
+        evidence_refs=(),
+        summary="The second narrow Web UI move worked well too.",
+    )
+
+    await sqlite_store.save_support_attempt(first_attempt)
+    await sqlite_store.save_support_learning_case(first_case)
+
+    first_result = await sqlite_store.apply_support_case_learning(first_case.case_id)
+
+    assert first_result is not None
+    assert await sqlite_store.list_support_value_ledger_entries() == [
+        SupportValueLedgerEntry(
+            value_id="value-relational-candor-arc-webui_cleanup-high",
+            registry="relational",
+            dimension="candor",
+            scope=SupportProfileScope(type="arc", id="webui_cleanup"),
+            value="high",
+            status="shadow",
+            source="auto_case",
+            confidence=0.81,
+            evidence_count=1,
+            contradiction_count=0,
+            last_case_id="case-webui-1",
+            created_at=datetime(2026, 4, 7, 16, 5, tzinfo=UTC),
+            updated_at=datetime(2026, 4, 7, 16, 5, tzinfo=UTC),
+            why="relational candor=high has 1 supporting promotable cases and 0 conflicting promotable cases in this arc scope.",
+        ),
+        SupportValueLedgerEntry(
+            value_id="value-support-option_bandwidth-arc-webui_cleanup-single",
+            registry="support",
+            dimension="option_bandwidth",
+            scope=SupportProfileScope(type="arc", id="webui_cleanup"),
+            value="single",
+            status="shadow",
+            source="auto_case",
+            confidence=0.81,
+            evidence_count=1,
+            contradiction_count=0,
+            last_case_id="case-webui-1",
+            created_at=datetime(2026, 4, 7, 16, 5, tzinfo=UTC),
+            updated_at=datetime(2026, 4, 7, 16, 5, tzinfo=UTC),
+            why="support option_bandwidth=single has 1 supporting promotable cases and 0 conflicting promotable cases in this arc scope.",
+        ),
+    ]
+
+    await sqlite_store.save_support_attempt(second_attempt)
+    await sqlite_store.save_support_learning_case(second_case)
+
+    second_result = await sqlite_store.apply_support_case_learning(second_case.case_id)
+
+    assert second_result is not None
+    assert await sqlite_store.list_support_value_ledger_entries() == [
+        SupportValueLedgerEntry(
+            value_id="value-relational-candor-arc-webui_cleanup-high",
+            registry="relational",
+            dimension="candor",
+            scope=SupportProfileScope(type="arc", id="webui_cleanup"),
+            value="high",
+            status="active_auto",
+            source="auto_case",
+            confidence=0.82,
+            evidence_count=2,
+            contradiction_count=0,
+            last_case_id="case-webui-2",
+            created_at=datetime(2026, 4, 7, 16, 5, tzinfo=UTC),
+            updated_at=datetime(2026, 4, 7, 16, 15, tzinfo=UTC),
+            why="relational candor=high has 2 supporting promotable cases and 0 conflicting promotable cases in this arc scope.",
+        ),
+        SupportValueLedgerEntry(
+            value_id="value-support-option_bandwidth-arc-webui_cleanup-single",
+            registry="support",
+            dimension="option_bandwidth",
+            scope=SupportProfileScope(type="arc", id="webui_cleanup"),
+            value="single",
+            status="active_auto",
+            source="auto_case",
+            confidence=0.82,
+            evidence_count=2,
+            contradiction_count=0,
+            last_case_id="case-webui-2",
+            created_at=datetime(2026, 4, 7, 16, 5, tzinfo=UTC),
+            updated_at=datetime(2026, 4, 7, 16, 15, tzinfo=UTC),
+            why="support option_bandwidth=single has 2 supporting promotable cases and 0 conflicting promotable cases in this arc scope.",
+        ),
+    ]
+    assert await sqlite_store.list_support_ledger_update_events() == [
+        SupportLedgerUpdateEvent(
+            event_id="event-value-relational-candor-arc-webui_cleanup-high-shadow-case-webui-1",
+            entity_type="value",
+            entity_id="value-relational-candor-arc-webui_cleanup-high",
+            registry="relational",
+            dimension_or_kind="candor",
+            scope=SupportProfileScope(type="arc", id="webui_cleanup"),
+            old_status=None,
+            new_status="shadow",
+            old_value=None,
+            new_value="high",
+            trigger_case_ids=("case-webui-1",),
+            reason="relational candor=high has 1 supporting promotable cases and 0 conflicting promotable cases in this arc scope.",
+            confidence=0.81,
+            created_at=datetime(2026, 4, 7, 16, 5, tzinfo=UTC),
+        ),
+        SupportLedgerUpdateEvent(
+            event_id="event-value-support-option_bandwidth-arc-webui_cleanup-single-shadow-case-webui-1",
+            entity_type="value",
+            entity_id="value-support-option_bandwidth-arc-webui_cleanup-single",
+            registry="support",
+            dimension_or_kind="option_bandwidth",
+            scope=SupportProfileScope(type="arc", id="webui_cleanup"),
+            old_status=None,
+            new_status="shadow",
+            old_value=None,
+            new_value="single",
+            trigger_case_ids=("case-webui-1",),
+            reason=(
+                "support option_bandwidth=single has 1 supporting promotable cases and 0 "
+                "conflicting promotable cases in this arc scope."
+            ),
+            confidence=0.81,
+            created_at=datetime(2026, 4, 7, 16, 5, tzinfo=UTC),
+        ),
+        SupportLedgerUpdateEvent(
+            event_id="event-value-relational-candor-arc-webui_cleanup-high-active_auto-case-webui-2",
+            entity_type="value",
+            entity_id="value-relational-candor-arc-webui_cleanup-high",
+            registry="relational",
+            dimension_or_kind="candor",
+            scope=SupportProfileScope(type="arc", id="webui_cleanup"),
+            old_status="shadow",
+            new_status="active_auto",
+            old_value="high",
+            new_value="high",
+            trigger_case_ids=("case-webui-1", "case-webui-2"),
+            reason="relational candor=high has 2 supporting promotable cases and 0 conflicting promotable cases in this arc scope.",
+            confidence=0.82,
+            created_at=datetime(2026, 4, 7, 16, 15, tzinfo=UTC),
+        ),
+        SupportLedgerUpdateEvent(
+            event_id="event-value-support-option_bandwidth-arc-webui_cleanup-single-active_auto-case-webui-2",
+            entity_type="value",
+            entity_id="value-support-option_bandwidth-arc-webui_cleanup-single",
+            registry="support",
+            dimension_or_kind="option_bandwidth",
+            scope=SupportProfileScope(type="arc", id="webui_cleanup"),
+            old_status="shadow",
+            new_status="active_auto",
+            old_value="single",
+            new_value="single",
+            trigger_case_ids=("case-webui-1", "case-webui-2"),
+            reason=(
+                "support option_bandwidth=single has 2 supporting promotable cases and 0 "
+                "conflicting promotable cases in this arc scope."
+            ),
+            confidence=0.82,
+            created_at=datetime(2026, 4, 7, 16, 15, tzinfo=UTC),
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_sqlite_store_apply_support_case_learning_skips_missing_or_non_promotable_cases(sqlite_store):
+    """Applying case learning should skip missing, open, and non-promotable cases without fabricating ledger rows."""
+
+    session_id = "sess-apply-case-learning-skips"
+    await sqlite_store.save_session(
+        session_id,
+        [
+            {
+                "idx": 0,
+                "id": "msg-10",
+                "role": "user",
+                "timestamp": "2026-04-07T17:00:00+00:00",
+                "content": "Help me inspect the docs refresh.",
+            },
+            {
+                "idx": 1,
+                "id": "msg-11",
+                "role": "assistant",
+                "timestamp": "2026-04-07T17:01:00+00:00",
+                "content": "Let's inspect it without forcing a conclusion.",
+            },
+            {
+                "idx": 2,
+                "id": "msg-12",
+                "role": "user",
+                "timestamp": "2026-04-07T17:10:00+00:00",
+                "content": "Help me inspect another ambiguous docs thread.",
+            },
+            {
+                "idx": 3,
+                "id": "msg-13",
+                "role": "assistant",
+                "timestamp": "2026-04-07T17:11:00+00:00",
+                "content": "Still no forced conclusion.",
+            },
+        ],
+        {"topic": "apply-case-learning-skips"},
+    )
+
+    open_attempt = SupportAttempt(
+        attempt_id="attempt-open-1",
+        session_id=session_id,
+        user_message_id="msg-10",
+        assistant_message_id="msg-11",
+        created_at=datetime(2026, 4, 7, 17, 1, tzinfo=UTC),
+        need="reflect",
+        response_mode="review",
+        subject_refs=("domain:work",),
+        active_arc_id=None,
+        active_domain_ids=("work",),
+        effective_support_values={"reflection_depth": "medium"},
+        effective_relational_values={"warmth": "high"},
+        intervention_family="mirror",
+        intervention_refs=(),
+        prompt_contract_summary="Reflect without forcing a conclusion.",
+        operational_snapshot_ref=None,
+    )
+    open_case = LearningCase(
+        case_id="case-open-1",
+        attempt_id=open_attempt.attempt_id,
+        status="open",
+        scope=SupportProfileScope(type="context", id="review"),
+        created_at=open_attempt.created_at,
+        finalized_at=None,
+        aggregate_signals=(),
+        positive_evidence_count=0,
+        negative_evidence_count=0,
+        contradiction_count=0,
+        conversation_score=0.0,
+        operational_score=0.0,
+        overall_score=0.0,
+        promotion_eligibility=False,
+        evidence_refs=(),
+        summary=None,
+    )
+    non_promotable_attempt = SupportAttempt(
+        attempt_id="attempt-non-promotable-1",
+        session_id=session_id,
+        user_message_id="msg-12",
+        assistant_message_id="msg-13",
+        created_at=datetime(2026, 4, 7, 17, 11, tzinfo=UTC),
+        need="reflect",
+        response_mode="review",
+        subject_refs=("domain:work",),
+        active_arc_id=None,
+        active_domain_ids=("work",),
+        effective_support_values={"reflection_depth": "medium"},
+        effective_relational_values={"warmth": "high"},
+        intervention_family="mirror",
+        intervention_refs=(),
+        prompt_contract_summary="Reflect without forcing a conclusion.",
+        operational_snapshot_ref=None,
+    )
+    non_promotable_case = LearningCase(
+        case_id="case-non-promotable-1",
+        attempt_id=non_promotable_attempt.attempt_id,
+        status="complete",
+        scope=SupportProfileScope(type="context", id="review"),
+        created_at=non_promotable_attempt.created_at,
+        finalized_at=datetime(2026, 4, 7, 17, 15, tzinfo=UTC),
+        aggregate_signals=("follow_up_needed",),
+        positive_evidence_count=0,
+        negative_evidence_count=1,
+        contradiction_count=1,
+        conversation_score=0.25,
+        operational_score=0.0,
+        overall_score=0.25,
+        promotion_eligibility=False,
+        evidence_refs=(),
+        summary="The attempt stayed ambiguous and should not promote learning.",
+    )
+
+    await sqlite_store.save_support_attempt(open_attempt)
+    await sqlite_store.save_support_attempt(non_promotable_attempt)
+    await sqlite_store.save_support_learning_case(open_case)
+    await sqlite_store.save_support_learning_case(non_promotable_case)
+
+    assert await sqlite_store.apply_support_case_learning("case-missing") is None
+    assert await sqlite_store.apply_support_case_learning(open_case.case_id) is None
+    assert await sqlite_store.apply_support_case_learning(non_promotable_case.case_id) is None
+    assert await sqlite_store.list_support_value_ledger_entries() == []
+    assert await sqlite_store.list_support_ledger_update_events() == []
+
+
+@pytest.mark.asyncio
 async def test_sqlite_store_rejects_support_attempt_without_real_session_and_message_refs(sqlite_store):
     """The store should reject fabricated support-attempt refs and leave v2 rows unchanged."""
 

--- a/tests/storage/test_support_learning_storage.py
+++ b/tests/storage/test_support_learning_storage.py
@@ -573,6 +573,226 @@ async def test_sqlite_store_skips_work_state_transition_observations_without_mat
 
 
 @pytest.mark.asyncio
+async def test_sqlite_store_work_state_transition_finalizes_case_and_applies_v2_value_ledger_updates(sqlite_store):
+    """Work-state transitions should finalize cases and apply v2 case learning (operational-only runner)."""
+
+    domain = LifeDomain(
+        domain_id="domain-work",
+        name="Work",
+        status="active",
+        salience=0.9,
+        created_at=datetime(2026, 4, 7, 14, 30, tzinfo=UTC),
+        updated_at=datetime(2026, 4, 7, 14, 30, tzinfo=UTC),
+    )
+    arc = OperationalArc(
+        arc_id="arc-webui-cleanup",
+        title="Web UI cleanup",
+        kind="project",
+        primary_domain_id=domain.domain_id,
+        status="active",
+        salience=0.93,
+        created_at=datetime(2026, 4, 7, 14, 30, tzinfo=UTC),
+        updated_at=datetime(2026, 4, 7, 14, 31, tzinfo=UTC),
+        last_active_at=datetime(2026, 4, 7, 14, 31, tzinfo=UTC),
+    )
+    task = ArcTask(
+        task_id="task-split-bootstrap-flow",
+        arc_id=arc.arc_id,
+        title="Split bootstrap flow",
+        status="todo",
+        created_at=datetime(2026, 4, 7, 14, 32, tzinfo=UTC),
+        updated_at=datetime(2026, 4, 7, 14, 32, tzinfo=UTC),
+        next_step="List the current boot responsibilities",
+    )
+
+    await sqlite_store.save_life_domain(domain)
+    await sqlite_store.save_operational_arc(arc)
+    await sqlite_store.save_arc_task(task)
+
+    session_id = "sess-work-state-case-learning"
+    await sqlite_store.save_session(
+        session_id,
+        [
+            {
+                "idx": 0,
+                "id": "msg-0",
+                "role": "user",
+                "timestamp": "2026-04-07T14:33:00+00:00",
+                "content": "Help me resume the Web UI cleanup.",
+            },
+            {
+                "idx": 1,
+                "id": "msg-1",
+                "role": "assistant",
+                "timestamp": "2026-04-07T14:34:00+00:00",
+                "content": "Okay — one narrow next step.",
+            },
+        ],
+        {"topic": "work-state-case-learning"},
+    )
+
+    attempt = SupportAttempt(
+        attempt_id="attempt-work-state-1",
+        session_id=session_id,
+        user_message_id="msg-0",
+        assistant_message_id="msg-1",
+        created_at=datetime(2026, 4, 7, 14, 34, tzinfo=UTC),
+        need="resume",
+        response_mode="execute",
+        subject_refs=("arc:arc-webui-cleanup",),
+        active_arc_id=arc.arc_id,
+        active_domain_ids=("work",),
+        effective_support_values={"option_bandwidth": "single"},
+        effective_relational_values={"candor": "high"},
+        intervention_family="summarize",
+        intervention_refs=(),
+        prompt_contract_summary="Resume the arc with one narrow next move.",
+        operational_snapshot_ref=None,
+    )
+    await sqlite_store.save_support_attempt(attempt)
+
+    await sqlite_store.save_arc_task(
+        ArcTask(
+            task_id=task.task_id,
+            arc_id=task.arc_id,
+            title=task.title,
+            status="done",
+            created_at=task.created_at,
+            updated_at=datetime(2026, 4, 7, 14, 35, tzinfo=UTC),
+            next_step="",
+        )
+    )
+
+    observations = await sqlite_store.list_support_outcome_observations(attempt.attempt_id)
+    assert [observation.signals for observation in observations] == [("task_completed",)]
+
+    learning_case = await sqlite_store.get_support_learning_case(f"case-{attempt.attempt_id}")
+    assert learning_case is not None
+    assert learning_case.status == "complete"
+    assert learning_case.promotion_eligibility is True
+
+    value_entries = await sqlite_store.list_support_value_ledger_entries()
+    assert any(
+        entry.registry == "support"
+        and entry.dimension == "option_bandwidth"
+        and entry.scope == SupportProfileScope(type="arc", id=arc.arc_id)
+        and entry.value == "single"
+        and entry.status == "shadow"
+        and entry.evidence_count == 1
+        for entry in value_entries
+    )
+
+    update_events = await sqlite_store.list_support_ledger_update_events()
+    assert any(
+        event.entity_type == "value"
+        and event.registry == "support"
+        and event.dimension_or_kind == "option_bandwidth"
+        and event.scope == SupportProfileScope(type="arc", id=arc.arc_id)
+        and event.new_status == "shadow"
+        and learning_case.case_id in event.trigger_case_ids
+        for event in update_events
+    )
+
+@pytest.mark.asyncio
+async def test_sqlite_store_work_state_transition_does_not_apply_case_learning_when_no_observation_is_written(
+    sqlite_store,
+):
+    """Operational writes should not finalize cases or write v2 ledger rows when no transition signal is emitted."""
+
+    domain = LifeDomain(
+        domain_id="domain-work",
+        name="Work",
+        status="active",
+        salience=0.9,
+        created_at=datetime(2026, 4, 7, 14, 40, tzinfo=UTC),
+        updated_at=datetime(2026, 4, 7, 14, 40, tzinfo=UTC),
+    )
+    arc = OperationalArc(
+        arc_id="arc-webui-cleanup",
+        title="Web UI cleanup",
+        kind="project",
+        primary_domain_id=domain.domain_id,
+        status="active",
+        salience=0.93,
+        created_at=datetime(2026, 4, 7, 14, 40, tzinfo=UTC),
+        updated_at=datetime(2026, 4, 7, 14, 41, tzinfo=UTC),
+        last_active_at=datetime(2026, 4, 7, 14, 41, tzinfo=UTC),
+    )
+    task = ArcTask(
+        task_id="task-split-bootstrap-flow",
+        arc_id=arc.arc_id,
+        title="Split bootstrap flow",
+        status="todo",
+        created_at=datetime(2026, 4, 7, 14, 42, tzinfo=UTC),
+        updated_at=datetime(2026, 4, 7, 14, 42, tzinfo=UTC),
+        next_step="List the current boot responsibilities",
+    )
+
+    await sqlite_store.save_life_domain(domain)
+    await sqlite_store.save_operational_arc(arc)
+    await sqlite_store.save_arc_task(task)
+
+    session_id = "sess-work-state-case-learning-noop"
+    await sqlite_store.save_session(
+        session_id,
+        [
+            {
+                "idx": 0,
+                "id": "msg-0",
+                "role": "user",
+                "timestamp": "2026-04-07T14:43:00+00:00",
+                "content": "Help me resume the Web UI cleanup.",
+            },
+            {
+                "idx": 1,
+                "id": "msg-1",
+                "role": "assistant",
+                "timestamp": "2026-04-07T14:44:00+00:00",
+                "content": "Okay — one narrow next step.",
+            },
+        ],
+        {"topic": "work-state-case-learning-noop"},
+    )
+
+    attempt = SupportAttempt(
+        attempt_id="attempt-work-state-noop-1",
+        session_id=session_id,
+        user_message_id="msg-0",
+        assistant_message_id="msg-1",
+        created_at=datetime(2026, 4, 7, 14, 44, tzinfo=UTC),
+        need="resume",
+        response_mode="execute",
+        subject_refs=("arc:arc-webui-cleanup",),
+        active_arc_id=arc.arc_id,
+        active_domain_ids=("work",),
+        effective_support_values={"option_bandwidth": "single"},
+        effective_relational_values={"candor": "high"},
+        intervention_family="summarize",
+        intervention_refs=(),
+        prompt_contract_summary="Resume the arc with one narrow next move.",
+        operational_snapshot_ref=None,
+    )
+    await sqlite_store.save_support_attempt(attempt)
+
+    await sqlite_store.save_arc_task(
+        ArcTask(
+            task_id=task.task_id,
+            arc_id=task.arc_id,
+            title=task.title,
+            status="todo",
+            created_at=task.created_at,
+            updated_at=datetime(2026, 4, 7, 14, 45, tzinfo=UTC),
+            next_step=task.next_step,
+        )
+    )
+
+    assert await sqlite_store.list_support_outcome_observations(attempt.attempt_id) == []
+    assert await sqlite_store.get_support_learning_case(f"case-{attempt.attempt_id}") is None
+    assert await sqlite_store.list_support_value_ledger_entries() == []
+    assert await sqlite_store.list_support_ledger_update_events() == []
+
+
+@pytest.mark.asyncio
 async def test_sqlite_store_finalize_support_learning_case_persists_scored_case_from_attempt_observations(sqlite_store):
     """The store should finalize and persist one deterministic learning case from a stored attempt bundle."""
 

--- a/tests/storage/test_support_learning_storage.py
+++ b/tests/storage/test_support_learning_storage.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
+import aiosqlite
 import pytest
 
 from alfred.memory.support_learning import (
@@ -201,6 +202,43 @@ async def test_sqlite_store_round_trips_v2_learning_case_bundle(sqlite_store):
     assert await sqlite_store.list_support_value_ledger_entries() == [value_entry]
     assert await sqlite_store.get_support_pattern_ledger_entry("pattern-webui-directness") == pattern_entry
     assert await sqlite_store.list_support_ledger_update_events() == [update_event]
+
+
+@pytest.mark.asyncio
+async def test_sqlite_store_rejects_support_attempt_without_real_session_and_message_refs(sqlite_store):
+    """The store should reject fabricated support-attempt refs and leave v2 rows unchanged."""
+
+    invalid_attempt = SupportAttempt(
+        attempt_id="attempt-invalid",
+        session_id="runtime",
+        user_message_id="msg-user-missing",
+        assistant_message_id="msg-assistant-missing",
+        created_at=datetime(2026, 4, 7, 12, 40, tzinfo=UTC),
+        need="activate",
+        response_mode="execute",
+        subject_refs=("arc:webui_cleanup",),
+        active_arc_id="webui_cleanup",
+        active_domain_ids=("work",),
+        effective_support_values={"option_bandwidth": "single"},
+        effective_relational_values={"candor": "high"},
+        intervention_family="narrow",
+        intervention_refs=("int-webui-missing",),
+        prompt_contract_summary="Keep the next move narrow and direct.",
+        operational_snapshot_ref="arc:webui_cleanup@snap-invalid",
+    )
+
+    with pytest.raises(ValueError, match="real persisted session/message refs"):
+        await sqlite_store.save_support_attempt(invalid_attempt)
+
+    assert await sqlite_store.get_support_attempt("attempt-invalid") is None
+
+    async with (
+        aiosqlite.connect(sqlite_store.db_path) as db,
+        db.execute("SELECT COUNT(*) FROM support_attempts") as cursor,
+    ):
+        row = await cursor.fetchone()
+    assert row is not None
+    assert row[0] == 0
 
 
 @pytest.mark.asyncio

--- a/tests/storage/test_support_learning_storage.py
+++ b/tests/storage/test_support_learning_storage.py
@@ -7,10 +7,16 @@ from datetime import UTC, datetime
 import pytest
 
 from alfred.memory.support_learning import (
+    LearningCase,
     LearningSituation,
+    OutcomeObservation,
+    SupportAttempt,
+    SupportLedgerUpdateEvent,
     SupportPattern,
+    SupportPatternLedgerEntry,
     SupportProfileUpdateEvent,
     SupportTranscriptSpanRef,
+    SupportValueLedgerEntry,
 )
 from alfred.memory.support_profile import SupportProfileScope
 from alfred.storage.sqlite import SQLiteStore
@@ -22,6 +28,179 @@ async def sqlite_store(tmp_path):
     store = SQLiteStore(tmp_path / "support_learning.db", embedding_dim=4)
     await store._init()
     return store
+
+
+@pytest.mark.asyncio
+async def test_sqlite_store_round_trips_v2_learning_case_bundle(sqlite_store):
+    """The store should round-trip one v2 case bundle without losing refs or ordering."""
+
+    session_id = "sess-v2-case-bundle"
+    messages = [
+        {
+            "idx": 0,
+            "id": "msg-0",
+            "role": "user",
+            "timestamp": "2026-04-07T12:00:00+00:00",
+            "content": "Help me start the Web UI bootstrap cleanup.",
+        },
+        {
+            "idx": 1,
+            "id": "msg-1",
+            "role": "assistant",
+            "timestamp": "2026-04-07T12:01:00+00:00",
+            "content": "Let's keep it narrow and choose one next move.",
+        },
+        {
+            "idx": 2,
+            "id": "msg-2",
+            "role": "user",
+            "timestamp": "2026-04-07T12:05:00+00:00",
+            "content": "Okay, I started the bootstrap task and narrowed the blocker.",
+        },
+    ]
+    await sqlite_store.save_session(session_id, messages, {"topic": "support-learning-v2"})
+
+    attempt = SupportAttempt(
+        attempt_id="attempt-webui-1",
+        session_id=session_id,
+        user_message_id="msg-0",
+        assistant_message_id="msg-1",
+        created_at=datetime(2026, 4, 7, 12, 1, tzinfo=UTC),
+        need="activate",
+        response_mode="execute",
+        subject_refs=("arc:webui_cleanup", "domain:work"),
+        active_arc_id="webui_cleanup",
+        active_domain_ids=("work",),
+        effective_support_values={"option_bandwidth": "single"},
+        effective_relational_values={"candor": "high"},
+        intervention_family="narrow",
+        intervention_refs=("int-webui-1",),
+        prompt_contract_summary="Keep the next move narrow and direct.",
+        operational_snapshot_ref="arc:webui_cleanup@snap-2026-04-07T12:01:00Z",
+    )
+    observations = [
+        OutcomeObservation(
+            observation_id="obs-webui-1",
+            attempt_id="attempt-webui-1",
+            observed_at=datetime(2026, 4, 7, 12, 5, tzinfo=UTC),
+            source_type="next_user_turn",
+            signals=("clarity", "commitment"),
+            signal_polarity="positive",
+            signal_strength=0.76,
+            evidence_refs=(
+                SupportTranscriptSpanRef(
+                    session_id=session_id,
+                    message_start_id="msg-2",
+                    message_end_id="msg-2",
+                ),
+            ),
+            notes="The user endorsed the narrow plan and showed commitment.",
+        ),
+        OutcomeObservation(
+            observation_id="obs-webui-2",
+            attempt_id="attempt-webui-1",
+            observed_at=datetime(2026, 4, 7, 12, 6, tzinfo=UTC),
+            source_type="work_state_transition",
+            signals=("task_started", "blocker_narrowed"),
+            signal_polarity="positive",
+            signal_strength=0.88,
+            evidence_refs=(
+                SupportTranscriptSpanRef(
+                    session_id=session_id,
+                    message_start_id="msg-2",
+                    message_end_id="msg-2",
+                ),
+            ),
+            operational_delta_refs=("task:webui-bootstrap", "blocker:script-order"),
+            notes="The user started the task and narrowed the blocker.",
+        ),
+    ]
+    learning_case = LearningCase(
+        case_id="case-webui-1",
+        attempt_id="attempt-webui-1",
+        status="complete",
+        scope=SupportProfileScope(type="arc", id="webui_cleanup"),
+        created_at=datetime(2026, 4, 7, 12, 1, tzinfo=UTC),
+        finalized_at=datetime(2026, 4, 7, 12, 10, tzinfo=UTC),
+        aggregate_signals=("clarity", "commitment", "task_started", "blocker_narrowed"),
+        positive_evidence_count=4,
+        negative_evidence_count=0,
+        contradiction_count=0,
+        conversation_score=0.76,
+        operational_score=0.88,
+        overall_score=0.82,
+        promotion_eligibility=True,
+        evidence_refs=(
+            SupportTranscriptSpanRef(
+                session_id=session_id,
+                message_start_id="msg-0",
+                message_end_id="msg-2",
+            ),
+        ),
+        summary="Direct narrow execution support correlated with concrete movement.",
+    )
+    value_entry = SupportValueLedgerEntry(
+        value_id="val-bandwidth-arc-1",
+        registry="support",
+        dimension="option_bandwidth",
+        scope=SupportProfileScope(type="arc", id="webui_cleanup"),
+        value="single",
+        status="active_auto",
+        source="auto_case",
+        confidence=0.82,
+        evidence_count=2,
+        contradiction_count=0,
+        last_case_id="case-webui-1",
+        created_at=datetime(2026, 4, 7, 12, 10, tzinfo=UTC),
+        updated_at=datetime(2026, 4, 7, 12, 10, tzinfo=UTC),
+        why="Repeated successful cases favored a single next step in this arc.",
+    )
+    pattern_entry = SupportPatternLedgerEntry(
+        pattern_id="pattern-webui-directness",
+        registry="relational",
+        kind="support_preference",
+        scope=SupportProfileScope(type="context", id="execute"),
+        status="active_auto",
+        claim="Direct candor plus narrow execution support works well here.",
+        evidence_count=2,
+        contradiction_count=0,
+        confidence=0.8,
+        source_case_ids=("case-webui-1",),
+        created_at=datetime(2026, 4, 7, 12, 10, tzinfo=UTC),
+        updated_at=datetime(2026, 4, 7, 12, 10, tzinfo=UTC),
+        why="Multiple execute cases converged on the same pattern.",
+    )
+    update_event = SupportLedgerUpdateEvent(
+        event_id="evt-bandwidth-1",
+        entity_type="value",
+        entity_id="val-bandwidth-arc-1",
+        registry="support",
+        dimension_or_kind="option_bandwidth",
+        scope=SupportProfileScope(type="arc", id="webui_cleanup"),
+        old_status="shadow",
+        new_status="active_auto",
+        old_value="few",
+        new_value="single",
+        trigger_case_ids=("case-webui-1",),
+        reason="Strong recent cases favored a single next step for this arc.",
+        confidence=0.82,
+        created_at=datetime(2026, 4, 7, 12, 10, tzinfo=UTC),
+    )
+
+    await sqlite_store.save_support_attempt(attempt)
+    for observation in observations:
+        await sqlite_store.save_support_outcome_observation(observation)
+    await sqlite_store.save_support_learning_case(learning_case)
+    await sqlite_store.save_support_value_ledger_entry(value_entry)
+    await sqlite_store.save_support_pattern_ledger_entry(pattern_entry)
+    await sqlite_store.save_support_ledger_update_event(update_event)
+
+    assert await sqlite_store.get_support_attempt("attempt-webui-1") == attempt
+    assert await sqlite_store.list_support_outcome_observations("attempt-webui-1") == observations
+    assert await sqlite_store.get_support_learning_case("case-webui-1") == learning_case
+    assert await sqlite_store.list_support_value_ledger_entries() == [value_entry]
+    assert await sqlite_store.get_support_pattern_ledger_entry("pattern-webui-directness") == pattern_entry
+    assert await sqlite_store.list_support_ledger_update_events() == [update_event]
 
 
 @pytest.mark.asyncio

--- a/tests/storage/test_support_learning_storage.py
+++ b/tests/storage/test_support_learning_storage.py
@@ -19,6 +19,7 @@ from alfred.memory.support_learning import (
     SupportTranscriptSpanRef,
     SupportValueLedgerEntry,
 )
+from alfred.memory.support_memory import ArcBlocker, ArcOpenLoop, ArcTask, LifeDomain, OperationalArc
 from alfred.memory.support_profile import SupportProfileScope
 from alfred.storage.sqlite import SQLiteStore
 
@@ -202,6 +203,373 @@ async def test_sqlite_store_round_trips_v2_learning_case_bundle(sqlite_store):
     assert await sqlite_store.list_support_value_ledger_entries() == [value_entry]
     assert await sqlite_store.get_support_pattern_ledger_entry("pattern-webui-directness") == pattern_entry
     assert await sqlite_store.list_support_ledger_update_events() == [update_event]
+
+
+@pytest.mark.asyncio
+async def test_sqlite_store_records_work_state_transition_observations_for_latest_matching_arc_attempt(sqlite_store):
+    """Task, blocker, open-loop, and arc transitions should append work-state observations on the latest arc attempt."""
+
+    domain = LifeDomain(
+        domain_id="domain-work",
+        name="Work",
+        status="active",
+        salience=0.95,
+        created_at=datetime(2026, 4, 7, 12, 0, tzinfo=UTC),
+        updated_at=datetime(2026, 4, 7, 12, 0, tzinfo=UTC),
+    )
+    arc = OperationalArc(
+        arc_id="arc-webui-cleanup",
+        title="Web UI cleanup",
+        kind="project",
+        primary_domain_id=domain.domain_id,
+        status="dormant",
+        salience=0.94,
+        created_at=datetime(2026, 4, 7, 12, 0, tzinfo=UTC),
+        updated_at=datetime(2026, 4, 7, 12, 1, tzinfo=UTC),
+        last_active_at=datetime(2026, 4, 7, 11, 55, tzinfo=UTC),
+    )
+    task = ArcTask(
+        task_id="task-split-bootstrap-flow",
+        arc_id=arc.arc_id,
+        title="Split bootstrap flow",
+        status="todo",
+        created_at=datetime(2026, 4, 7, 12, 2, tzinfo=UTC),
+        updated_at=datetime(2026, 4, 7, 12, 2, tzinfo=UTC),
+        next_step="List the current boot responsibilities",
+    )
+    blocker = ArcBlocker(
+        blocker_id="blocker-app-structure-ambiguity",
+        arc_id=arc.arc_id,
+        title="App structure ambiguity",
+        status="active",
+        created_at=datetime(2026, 4, 7, 12, 3, tzinfo=UTC),
+        updated_at=datetime(2026, 4, 7, 12, 3, tzinfo=UTC),
+        next_step="Choose a bootstrap seam",
+    )
+    open_loop = ArcOpenLoop(
+        open_loop_id="loop-confirm-bootstrap-boundary",
+        arc_id=arc.arc_id,
+        title="Confirm bootstrap boundary",
+        status="waiting",
+        created_at=datetime(2026, 4, 7, 12, 4, tzinfo=UTC),
+        updated_at=datetime(2026, 4, 7, 12, 4, tzinfo=UTC),
+        current_tension="Need a crisp boundary before deeper edits",
+    )
+
+    await sqlite_store.save_life_domain(domain)
+    await sqlite_store.save_operational_arc(arc)
+    await sqlite_store.save_arc_task(task)
+    await sqlite_store.save_arc_blocker(blocker)
+    await sqlite_store.save_arc_open_loop(open_loop)
+
+    session_id = "sess-work-state-observations"
+    await sqlite_store.save_session(
+        session_id,
+        [
+            {
+                "idx": 0,
+                "id": "msg-0",
+                "role": "user",
+                "timestamp": "2026-04-07T12:05:00+00:00",
+                "content": "Help me resume the Web UI cleanup.",
+            },
+            {
+                "idx": 1,
+                "id": "msg-1",
+                "role": "assistant",
+                "timestamp": "2026-04-07T12:06:00+00:00",
+                "content": "Let's keep the next move narrow.",
+            },
+            {
+                "idx": 2,
+                "id": "msg-2",
+                "role": "user",
+                "timestamp": "2026-04-07T12:07:00+00:00",
+                "content": "Okay, what's the next concrete step?",
+            },
+            {
+                "idx": 3,
+                "id": "msg-3",
+                "role": "assistant",
+                "timestamp": "2026-04-07T12:08:00+00:00",
+                "content": "Start by extracting the bootstrap flow.",
+            },
+        ],
+        {"topic": "work-state-observations"},
+    )
+
+    older_attempt = SupportAttempt(
+        attempt_id="attempt-older",
+        session_id=session_id,
+        user_message_id="msg-0",
+        assistant_message_id="msg-1",
+        created_at=datetime(2026, 4, 7, 12, 6, tzinfo=UTC),
+        need="resume",
+        response_mode="execute",
+        subject_refs=("arc:arc-webui-cleanup",),
+        active_arc_id=arc.arc_id,
+        active_domain_ids=("work",),
+        effective_support_values={"option_bandwidth": "single"},
+        effective_relational_values={"candor": "high"},
+        intervention_family="summarize",
+        intervention_refs=(),
+        prompt_contract_summary="Resume the arc with one narrow next move.",
+        operational_snapshot_ref="arc:arc-webui-cleanup@snap-older",
+    )
+    latest_attempt = SupportAttempt(
+        attempt_id="attempt-latest",
+        session_id=session_id,
+        user_message_id="msg-2",
+        assistant_message_id="msg-3",
+        created_at=datetime(2026, 4, 7, 12, 8, tzinfo=UTC),
+        need="activate",
+        response_mode="execute",
+        subject_refs=("arc:arc-webui-cleanup",),
+        active_arc_id=arc.arc_id,
+        active_domain_ids=("work",),
+        effective_support_values={"option_bandwidth": "single"},
+        effective_relational_values={"candor": "high"},
+        intervention_family="narrow",
+        intervention_refs=(),
+        prompt_contract_summary="Turn the active arc into one concrete start step.",
+        operational_snapshot_ref="arc:arc-webui-cleanup@snap-latest",
+    )
+
+    await sqlite_store.save_support_attempt(older_attempt)
+    await sqlite_store.save_support_attempt(latest_attempt)
+
+    await sqlite_store.save_arc_task(
+        ArcTask(
+            task_id=task.task_id,
+            arc_id=task.arc_id,
+            title=task.title,
+            status="in_progress",
+            created_at=task.created_at,
+            updated_at=datetime(2026, 4, 7, 12, 9, tzinfo=UTC),
+            next_step="Move runtime boot into its own module",
+        )
+    )
+    await sqlite_store.save_arc_blocker(
+        ArcBlocker(
+            blocker_id=blocker.blocker_id,
+            arc_id=blocker.arc_id,
+            title=blocker.title,
+            status="resolved",
+            created_at=blocker.created_at,
+            updated_at=datetime(2026, 4, 7, 12, 10, tzinfo=UTC),
+            next_step="Chosen bootstrap seam",
+        )
+    )
+    await sqlite_store.save_arc_open_loop(
+        ArcOpenLoop(
+            open_loop_id=open_loop.open_loop_id,
+            arc_id=open_loop.arc_id,
+            title=open_loop.title,
+            status="resolved",
+            created_at=open_loop.created_at,
+            updated_at=datetime(2026, 4, 7, 12, 11, tzinfo=UTC),
+            current_tension="Boundary confirmed",
+        )
+    )
+    await sqlite_store.save_operational_arc(
+        OperationalArc(
+            arc_id=arc.arc_id,
+            title=arc.title,
+            kind=arc.kind,
+            primary_domain_id=arc.primary_domain_id,
+            status="active",
+            salience=0.97,
+            created_at=arc.created_at,
+            updated_at=datetime(2026, 4, 7, 12, 12, tzinfo=UTC),
+            last_active_at=datetime(2026, 4, 7, 12, 12, tzinfo=UTC),
+        )
+    )
+
+    observations = await sqlite_store.list_support_outcome_observations(latest_attempt.attempt_id)
+
+    assert await sqlite_store.list_support_outcome_observations(older_attempt.attempt_id) == []
+    assert [observation.source_type for observation in observations] == [
+        "work_state_transition",
+        "work_state_transition",
+        "work_state_transition",
+        "work_state_transition",
+    ]
+    assert [observation.signals for observation in observations] == [
+        ("task_started",),
+        ("blocker_resolved",),
+        ("open_loop_closed",),
+        ("arc_resumed",),
+    ]
+    assert [observation.signal_polarity for observation in observations] == [
+        "positive",
+        "positive",
+        "positive",
+        "positive",
+    ]
+    assert [observation.operational_delta_refs for observation in observations] == [
+        ("arc:arc-webui-cleanup", "task:task-split-bootstrap-flow"),
+        ("arc:arc-webui-cleanup", "blocker:blocker-app-structure-ambiguity"),
+        ("arc:arc-webui-cleanup", "open_loop:loop-confirm-bootstrap-boundary"),
+        ("arc:arc-webui-cleanup",),
+    ]
+    assert [observation.observed_at for observation in observations] == [
+        datetime(2026, 4, 7, 12, 9, tzinfo=UTC),
+        datetime(2026, 4, 7, 12, 10, tzinfo=UTC),
+        datetime(2026, 4, 7, 12, 11, tzinfo=UTC),
+        datetime(2026, 4, 7, 12, 12, tzinfo=UTC),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_sqlite_store_skips_work_state_transition_observations_without_matching_arc_attempt_or_status_change(sqlite_store):
+    """Operational writes should skip observation persistence when no matching attempt exists or nothing changed."""
+
+    domain = LifeDomain(
+        domain_id="domain-work",
+        name="Work",
+        status="active",
+        salience=0.91,
+        created_at=datetime(2026, 4, 7, 13, 0, tzinfo=UTC),
+        updated_at=datetime(2026, 4, 7, 13, 0, tzinfo=UTC),
+    )
+    arc = OperationalArc(
+        arc_id="arc-webui-cleanup",
+        title="Web UI cleanup",
+        kind="project",
+        primary_domain_id=domain.domain_id,
+        status="active",
+        salience=0.93,
+        created_at=datetime(2026, 4, 7, 13, 0, tzinfo=UTC),
+        updated_at=datetime(2026, 4, 7, 13, 1, tzinfo=UTC),
+        last_active_at=datetime(2026, 4, 7, 13, 1, tzinfo=UTC),
+    )
+    other_arc = OperationalArc(
+        arc_id="arc-docs-refresh",
+        title="Docs refresh",
+        kind="project",
+        primary_domain_id=domain.domain_id,
+        status="active",
+        salience=0.72,
+        created_at=datetime(2026, 4, 7, 13, 0, tzinfo=UTC),
+        updated_at=datetime(2026, 4, 7, 13, 2, tzinfo=UTC),
+        last_active_at=datetime(2026, 4, 7, 13, 2, tzinfo=UTC),
+    )
+    task = ArcTask(
+        task_id="task-outline-bootstrap-boundary",
+        arc_id=arc.arc_id,
+        title="Outline bootstrap boundary",
+        status="todo",
+        created_at=datetime(2026, 4, 7, 13, 3, tzinfo=UTC),
+        updated_at=datetime(2026, 4, 7, 13, 3, tzinfo=UTC),
+        next_step="List the boot responsibilities",
+    )
+
+    await sqlite_store.save_life_domain(domain)
+    await sqlite_store.save_operational_arc(arc)
+    await sqlite_store.save_operational_arc(other_arc)
+    await sqlite_store.save_arc_task(task)
+
+    session_id = "sess-work-state-skips"
+    await sqlite_store.save_session(
+        session_id,
+        [
+            {
+                "idx": 0,
+                "id": "msg-10",
+                "role": "user",
+                "timestamp": "2026-04-07T13:04:00+00:00",
+                "content": "Help me with the docs refresh arc.",
+            },
+            {
+                "idx": 1,
+                "id": "msg-11",
+                "role": "assistant",
+                "timestamp": "2026-04-07T13:05:00+00:00",
+                "content": "Let's pick one docs task.",
+            },
+            {
+                "idx": 2,
+                "id": "msg-12",
+                "role": "user",
+                "timestamp": "2026-04-07T13:06:00+00:00",
+                "content": "Actually, help me with Web UI cleanup.",
+            },
+            {
+                "idx": 3,
+                "id": "msg-13",
+                "role": "assistant",
+                "timestamp": "2026-04-07T13:07:00+00:00",
+                "content": "Okay, keep it narrow.",
+            },
+        ],
+        {"topic": "work-state-skips"},
+    )
+
+    unrelated_attempt = SupportAttempt(
+        attempt_id="attempt-docs-refresh",
+        session_id=session_id,
+        user_message_id="msg-10",
+        assistant_message_id="msg-11",
+        created_at=datetime(2026, 4, 7, 13, 5, tzinfo=UTC),
+        need="activate",
+        response_mode="execute",
+        subject_refs=("arc:arc-docs-refresh",),
+        active_arc_id=other_arc.arc_id,
+        active_domain_ids=("work",),
+        effective_support_values={"option_bandwidth": "single"},
+        effective_relational_values={"candor": "high"},
+        intervention_family="narrow",
+        intervention_refs=(),
+        prompt_contract_summary="Keep the docs move narrow and concrete.",
+        operational_snapshot_ref="arc:arc-docs-refresh@snap-1",
+    )
+    matching_attempt = SupportAttempt(
+        attempt_id="attempt-webui-cleanup",
+        session_id=session_id,
+        user_message_id="msg-12",
+        assistant_message_id="msg-13",
+        created_at=datetime(2026, 4, 7, 13, 7, tzinfo=UTC),
+        need="activate",
+        response_mode="execute",
+        subject_refs=("arc:arc-webui-cleanup",),
+        active_arc_id=arc.arc_id,
+        active_domain_ids=("work",),
+        effective_support_values={"option_bandwidth": "single"},
+        effective_relational_values={"candor": "high"},
+        intervention_family="narrow",
+        intervention_refs=(),
+        prompt_contract_summary="Keep the Web UI move narrow and concrete.",
+        operational_snapshot_ref="arc:arc-webui-cleanup@snap-1",
+    )
+
+    await sqlite_store.save_support_attempt(unrelated_attempt)
+    await sqlite_store.save_arc_task(
+        ArcTask(
+            task_id=task.task_id,
+            arc_id=task.arc_id,
+            title=task.title,
+            status="in_progress",
+            created_at=task.created_at,
+            updated_at=datetime(2026, 4, 7, 13, 6, tzinfo=UTC),
+            next_step="Extract the runtime boot path",
+        )
+    )
+
+    await sqlite_store.save_support_attempt(matching_attempt)
+    await sqlite_store.save_arc_task(
+        ArcTask(
+            task_id=task.task_id,
+            arc_id=task.arc_id,
+            title=task.title,
+            status="in_progress",
+            created_at=task.created_at,
+            updated_at=datetime(2026, 4, 7, 13, 8, tzinfo=UTC),
+            next_step="Extract the runtime boot path",
+        )
+    )
+
+    assert await sqlite_store.list_support_outcome_observations(unrelated_attempt.attempt_id) == []
+    assert await sqlite_store.list_support_outcome_observations(matching_attempt.attempt_id) == []
 
 
 @pytest.mark.asyncio

--- a/tests/storage/test_support_profile_storage.py
+++ b/tests/storage/test_support_profile_storage.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime
 
 import pytest
 
+from alfred.memory.support_learning import SupportValueLedgerEntry
 from alfred.memory.support_profile import SupportProfileScope, SupportProfileValue
 from alfred.storage.sqlite import SQLiteStore
 
@@ -149,3 +150,58 @@ async def test_sqlite_store_resolves_most_specific_support_profile_value(sqlite_
     )
     assert await sqlite_store.resolve_support_profile_value("support", "option_bandwidth") == global_value
     assert await sqlite_store.resolve_support_profile_value("support", "pacing", context_id="execute") is None
+
+
+@pytest.mark.asyncio
+async def test_sqlite_store_resolve_support_profile_value_prefers_v2_value_ledger_entries(sqlite_store):
+    """Resolution should prefer active v2 ledger entries over legacy v1 stored values."""
+    v1_context = SupportProfileValue(
+        registry="support",
+        dimension="option_bandwidth",
+        scope=SupportProfileScope(type="context", id="execute"),
+        value="few",
+        status="confirmed",
+        confidence=0.55,
+        source="explicit",
+        created_at=datetime(2026, 3, 30, 12, 0, tzinfo=UTC),
+        updated_at=datetime(2026, 3, 30, 12, 0, tzinfo=UTC),
+        evidence_refs=("ev-v1",),
+    )
+    await sqlite_store.save_support_profile_value(v1_context)
+
+    v2_entry = SupportValueLedgerEntry(
+        value_id="value-support-option_bandwidth-context-execute-single",
+        registry="support",
+        dimension="option_bandwidth",
+        scope=SupportProfileScope(type="context", id="execute"),
+        value="single",
+        status="active_auto",
+        source="auto_case",
+        confidence=0.81,
+        evidence_count=3,
+        contradiction_count=0,
+        last_case_id=None,
+        created_at=datetime(2026, 3, 30, 12, 5, tzinfo=UTC),
+        updated_at=datetime(2026, 3, 30, 12, 6, tzinfo=UTC),
+        why="Evidence threshold met.",
+    )
+    await sqlite_store.save_support_value_ledger_entry(v2_entry)
+
+    resolved = await sqlite_store.resolve_support_profile_value(
+        "support",
+        "option_bandwidth",
+        context_id="execute",
+    )
+
+    assert resolved == SupportProfileValue(
+        registry="support",
+        dimension="option_bandwidth",
+        scope=SupportProfileScope(type="context", id="execute"),
+        value="single",
+        status="confirmed",
+        confidence=0.81,
+        source="auto_adapted",
+        created_at=datetime(2026, 3, 30, 12, 5, tzinfo=UTC),
+        updated_at=datetime(2026, 3, 30, 12, 6, tzinfo=UTC),
+        evidence_refs=(),
+    )

--- a/tests/test_context_display.py
+++ b/tests/test_context_display.py
@@ -8,7 +8,42 @@ from unittest.mock import AsyncMock
 import pytest
 
 from alfred.context import ContextFile, ContextFileState
-from alfred.context_display import get_context_display
+from alfred.context_display import ContextConflictStatus, ContextStatus, get_context_display, get_context_status
+
+
+@pytest.mark.asyncio
+async def test_get_context_status_returns_typed_snapshot() -> None:
+    """The lightweight context-status helper should return a typed object, not a loose dict."""
+
+    blocked_soul = ContextFile(
+        name="soul",
+        path="/workspace/alfred/SOUL.md",
+        content="",
+        last_modified=datetime(2026, 3, 23, tzinfo=UTC),
+        state=ContextFileState.BLOCKED,
+        blocked_reason="Conflicted managed prompt fragment prompts/voice.md blocks SOUL.md",
+    )
+    fake_context_loader = SimpleNamespace(
+        load_all=AsyncMock(return_value={"soul": blocked_soul}),
+        get_disabled_sections=lambda: ["tools"],
+    )
+    fake_alfred = SimpleNamespace(context_loader=fake_context_loader)
+
+    result = await get_context_status(fake_alfred)
+
+    assert result == ContextStatus(
+        blocked_context_files=["SOUL.md"],
+        conflicted_context_files=[
+            ContextConflictStatus(
+                id="soul",
+                name="soul",
+                label="SOUL.md",
+                reason="Conflicted managed prompt fragment prompts/voice.md blocks SOUL.md",
+            )
+        ],
+        disabled_sections=["tools"],
+        warnings=["Disabled sections: tools"],
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_context_display.py
+++ b/tests/test_context_display.py
@@ -559,6 +559,45 @@ async def test_get_context_display_includes_support_state_summary() -> None:
                     timestamp=now,
                 ),
             ),
+            value_ledger_entries=(
+                SimpleNamespace(
+                    value_id="val-1",
+                    registry="support",
+                    dimension="option_bandwidth",
+                    scope=SimpleNamespace(type="context", id="execute"),
+                    value="single",
+                    status="active_auto",
+                    confidence=0.81,
+                    evidence_count=3,
+                    contradiction_count=0,
+                    last_case_id="case-1",
+                    updated_at=now,
+                    why="Evidence threshold met.",
+                ),
+            ),
+            value_ledger_summary={
+                "total": 1,
+                "counts_by_status": {"active_auto": 1},
+                "counts_by_registry": {"support": 1},
+            },
+            recent_ledger_update_events=(
+                SimpleNamespace(
+                    event_id="led-1",
+                    entity_type="value",
+                    entity_id="val-1",
+                    registry="support",
+                    dimension_or_kind="option_bandwidth",
+                    scope=SimpleNamespace(type="context", id="execute"),
+                    old_status=None,
+                    new_status="active_auto",
+                    old_value=None,
+                    new_value="single",
+                    trigger_case_ids=("case-1",),
+                    reason="Evidence threshold met.",
+                    confidence=0.82,
+                    created_at=now,
+                ),
+            ),
             recent_interventions=(
                 SimpleNamespace(
                     situation_id="sit-1",
@@ -642,6 +681,45 @@ async def test_get_context_display_includes_support_state_summary() -> None:
             "reason": "The narrower pace improved follow-through.",
             "confidence": 0.88,
             "timestamp": now.isoformat(),
+        }
+    ]
+    assert support_state["learned_state"]["value_ledger_entries"] == [
+        {
+            "value_id": "val-1",
+            "registry": "support",
+            "dimension": "option_bandwidth",
+            "scope": {"type": "context", "id": "execute", "label": "context:execute"},
+            "value": "single",
+            "status": "active_auto",
+            "confidence": 0.81,
+            "evidence_count": 3,
+            "contradiction_count": 0,
+            "last_case_id": "case-1",
+            "updated_at": now.isoformat(),
+            "why": "Evidence threshold met.",
+        }
+    ]
+    assert support_state["learned_state"]["value_ledger_summary"] == {
+        "total": 1,
+        "counts_by_status": {"active_auto": 1},
+        "counts_by_registry": {"support": 1},
+    }
+    assert support_state["learned_state"]["recent_ledger_update_events"] == [
+        {
+            "event_id": "led-1",
+            "entity_type": "value",
+            "entity_id": "val-1",
+            "registry": "support",
+            "dimension_or_kind": "option_bandwidth",
+            "scope": {"type": "context", "id": "execute", "label": "context:execute"},
+            "old_status": None,
+            "new_status": "active_auto",
+            "old_value": None,
+            "new_value": "single",
+            "trigger_case_ids": ["case-1"],
+            "reason": "Evidence threshold met.",
+            "confidence": 0.82,
+            "created_at": now.isoformat(),
         }
     ]
     assert support_state["learned_state"]["recent_interventions"] == [

--- a/tests/test_context_integration.py
+++ b/tests/test_context_integration.py
@@ -315,6 +315,90 @@ class TestContextLoaderBlockedTemplates:
         assert "Upstream edit" not in system_prompt
         assert "# AGENTS" in system_prompt
 
+    @pytest.mark.asyncio
+    async def test_load_file_blocks_owner_when_managed_prompt_fragment_conflicts(
+        self,
+        config: Config,
+    ) -> None:
+        """A conflicted managed prompt fragment should block the owning top-level context file."""
+        soul_path = config.context_files["soul"]
+        prompts_dir = config.workspace_dir / "templates" / "prompts"
+        prompts_dir.mkdir(parents=True, exist_ok=True)
+        voice_template_path = prompts_dir / "voice.md"
+        cache_dir = config.workspace_dir / "cache"
+
+        initial_voice = "## Voice\n\nInitial voice guidance.\n"
+        local_voice = "## Voice\n\nLocal voice guidance.\n"
+        upstream_voice = "## Voice\n\nUpstream voice guidance.\n"
+
+        (config.workspace_dir / "templates" / "SOUL.md").write_text(
+            "# Soul\n\n{{prompts/voice.md}}\n",
+            encoding="utf-8",
+        )
+        voice_template_path.write_text(initial_voice, encoding="utf-8")
+
+        first_loader = ContextLoader(config, cache_dir=cache_dir)
+        created = await first_loader.load_file("soul", soul_path)
+        assert created.state is ContextFileState.ACTIVE
+        assert (config.workspace_dir / "prompts" / "voice.md").read_text(encoding="utf-8") == initial_voice
+
+        (config.workspace_dir / "prompts" / "voice.md").write_text(local_voice, encoding="utf-8")
+        voice_template_path.write_text(upstream_voice, encoding="utf-8")
+
+        restarted_loader = ContextLoader(config, cache_dir=cache_dir)
+        blocked = await restarted_loader.load_file("soul", soul_path)
+
+        assert blocked.state is ContextFileState.BLOCKED
+        assert blocked.blocked_reason is not None
+        assert "prompts/voice.md" in blocked.blocked_reason
+        assert "SOUL.md" in blocked.blocked_reason
+        assert restarted_loader.get_blocked_context_files() == ["soul"]
+
+    @pytest.mark.asyncio
+    async def test_load_file_reenables_owner_after_prompt_fragment_conflict_is_resolved(
+        self,
+        config: Config,
+    ) -> None:
+        """Manually resolving a conflicted managed prompt fragment should unblock the owner file."""
+        soul_path = config.context_files["soul"]
+        prompts_dir = config.workspace_dir / "templates" / "prompts"
+        prompts_dir.mkdir(parents=True, exist_ok=True)
+        voice_template_path = prompts_dir / "voice.md"
+        cache_dir = config.workspace_dir / "cache"
+
+        initial_voice = "## Voice\n\nInitial voice guidance.\n"
+        local_voice = "## Voice\n\nLocal voice guidance.\n"
+        upstream_voice = "## Voice\n\nUpstream voice guidance.\n"
+        resolved_voice = "## Voice\n\nMerged voice guidance.\n"
+
+        (config.workspace_dir / "templates" / "SOUL.md").write_text(
+            "# Soul\n\n{{prompts/voice.md}}\n",
+            encoding="utf-8",
+        )
+        voice_template_path.write_text(initial_voice, encoding="utf-8")
+
+        first_loader = ContextLoader(config, cache_dir=cache_dir)
+        created = await first_loader.load_file("soul", soul_path)
+        assert created.state is ContextFileState.ACTIVE
+
+        workspace_voice_path = config.workspace_dir / "prompts" / "voice.md"
+        workspace_voice_path.write_text(local_voice, encoding="utf-8")
+        voice_template_path.write_text(upstream_voice, encoding="utf-8")
+
+        conflicted_loader = ContextLoader(config, cache_dir=cache_dir)
+        blocked = await conflicted_loader.load_file("soul", soul_path)
+        assert blocked.state is ContextFileState.BLOCKED
+
+        workspace_voice_path.write_text(resolved_voice, encoding="utf-8")
+
+        resolved_loader = ContextLoader(config, cache_dir=cache_dir)
+        resolved = await resolved_loader.load_file("soul", soul_path)
+
+        assert resolved.state is ContextFileState.ACTIVE
+        assert resolved.blocked_reason is None
+        assert "Merged voice guidance." in resolved.content
+        assert resolved_loader.get_blocked_context_files() == []
+
 
 class TestTemplateManagerIntegration:
     """Integration tests for TemplateManager with real files."""

--- a/tests/test_core_observability.py
+++ b/tests/test_core_observability.py
@@ -165,11 +165,12 @@ class FakeSessionManager:
                 message_count=2,
             ),
             messages=[
-                Message(idx=0, role=Role.USER, content="previous user"),
-                Message(idx=1, role=Role.ASSISTANT, content="previous assistant"),
+                Message(idx=0, role=Role.USER, content="previous user", id="msg-seed-user"),
+                Message(idx=1, role=Role.ASSISTANT, content="previous assistant", id="msg-seed-assistant"),
             ],
         )
         self.persist_calls: list[tuple[str, int]] = []
+        self.strict_persist_calls: list[tuple[str, int]] = []
         self.token_updates: list[dict[str, Any]] = []
         self.add_message_calls: list[tuple[str, str, str | None]] = []
 
@@ -200,11 +201,15 @@ class FakeSessionManager:
             idx=len(self.session.messages),
             role=Role(role),
             content=content,
+            id=f"msg-{len(self.session.messages)}",
             timestamp=datetime.now(UTC),
         )
         self.session.messages.append(message)
         self.session.meta.last_active = datetime.now(UTC)
         self.session.meta.message_count = len(self.session.messages)
+
+    async def _persist_messages_strict(self, session_id: str, messages: list[Message]) -> None:
+        self.strict_persist_calls.append((session_id, len(messages)))
 
     def _spawn_persist_task(self, session_id: str, messages: list[Message]) -> None:
         self.persist_calls.append((session_id, len(messages)))
@@ -527,6 +532,115 @@ async def test_chat_stream_includes_compiled_support_contract_in_system_prompt(
     assert "## Runtime Support Contract" in agent.calls[0]["system_prompt"]
     assert "- need: activate" in agent.calls[0]["system_prompt"]
     assert "- intervention_family: narrow" in agent.calls[0]["system_prompt"]
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_persists_v2_support_attempt_with_real_refs(
+    tmp_path: Path,
+) -> None:
+    """chat_stream should persist one v2 support attempt only after real message refs exist."""
+
+    alfred, _, _, session_manager = _make_alfred(tmp_path)
+
+    class FakeSupportPolicyRuntime:
+        def __init__(self) -> None:
+            self.saved_attempts: list[dict[str, Any]] = []
+
+        async def build_turn_contract(
+            self,
+            *,
+            message: str,
+            query_embedding: list[float] | None,
+            session_messages: list[tuple[str, str]],
+            session_id: str | None = None,
+        ) -> Any:
+            del message, query_embedding, session_messages, session_id
+            assessment = SupportTurnAssessment(
+                need="activate",
+                subjects=(ResolvedSubject(kind="arc", id="webui_cleanup"),),
+            )
+            resolved_policy = ResolvedSupportPolicy(
+                assessment=assessment,
+                response_mode="execute",
+                relational_values={
+                    "warmth": "medium",
+                    "companionship": "medium",
+                    "candor": "medium",
+                    "challenge": "medium",
+                    "authority": "medium",
+                    "emotional_attunement": "medium",
+                    "analytical_depth": "medium",
+                    "momentum_pressure": "high",
+                },
+                support_values={
+                    "planning_granularity": "minimal",
+                    "option_bandwidth": "single",
+                    "proactivity_level": "high",
+                    "accountability_style": "firm",
+                    "recovery_style": "steady",
+                    "reflection_depth": "light",
+                    "pacing": "brisk",
+                    "recommendation_forcefulness": "high",
+                },
+                primary_arc_id="webui_cleanup",
+                domain_ids=("work",),
+            )
+            return SimpleNamespace(
+                assessment=assessment,
+                response_mode="execute",
+                resolved_policy=resolved_policy,
+                behavior_contract=compile_support_behavior_contract(resolved_policy),
+                trace=SimpleNamespace(),
+            )
+
+        async def save_support_attempt(
+            self,
+            *,
+            runtime_result: Any,
+            session_id: str,
+            user_message_id: str,
+            assistant_message_id: str,
+            created_at: datetime,
+        ) -> None:
+            assert session_manager.strict_persist_calls == [("session-observability", 4)]
+            self.saved_attempts.append(
+                {
+                    "session_id": session_id,
+                    "user_message_id": user_message_id,
+                    "assistant_message_id": assistant_message_id,
+                    "created_at": created_at,
+                    "need": runtime_result.assessment.need,
+                    "intervention_family": runtime_result.behavior_contract.intervention_family,
+                }
+            )
+
+    runtime = FakeSupportPolicyRuntime()
+    alfred._support_policy_runtime = runtime
+
+    chunks = [
+        chunk
+        async for chunk in alfred.chat_stream(
+            "hello world",
+            assistant_message_id="msg-assistant-live",
+        )
+    ]
+
+    assistant_message = session_manager.session.messages[-1]
+
+    assert chunks == ["Hello", " world"]
+    assert session_manager.strict_persist_calls == [("session-observability", 4)]
+    assert session_manager.persist_calls == []
+    assert runtime.saved_attempts == [
+        {
+            "session_id": "session-observability",
+            "user_message_id": "msg-2",
+            "assistant_message_id": "msg-assistant-live",
+            "created_at": assistant_message.timestamp,
+            "need": "activate",
+            "intervention_family": "narrow",
+        }
+    ]
+    assert assistant_message.id == "msg-assistant-live"
 
 
 @pytest.mark.asyncio

--- a/tests/test_support_learning.py
+++ b/tests/test_support_learning.py
@@ -7,7 +7,10 @@ from datetime import UTC, datetime
 import pytest
 
 from alfred.memory.support_learning import (
+    LearningCase,
     LearningSituation,
+    OutcomeObservation,
+    SupportAttempt,
     SupportPattern,
     SupportProfileUpdateEvent,
     SupportTranscriptSpanRef,
@@ -72,6 +75,90 @@ class FakePolicyValueStore:
                 if value.registry == registry and value.dimension == dimension and value.scope == scope:
                     return value
         return None
+
+
+def test_v2_learning_artifacts_round_trip_with_real_refs() -> None:
+    """Support attempts, observations, and cases should preserve the v2 storage contract."""
+
+    attempt = SupportAttempt(
+        attempt_id="attempt-webui-1",
+        session_id="sess-812",
+        user_message_id="msg-user-445",
+        assistant_message_id="msg-assistant-446",
+        created_at=datetime(2026, 4, 7, 12, 10, tzinfo=UTC),
+        need="activate",
+        response_mode="execute",
+        active_arc_id="webui_cleanup",
+        active_domain_ids=("work",),
+        subject_refs=("arc:webui_cleanup", "domain:work"),
+        effective_support_values={
+            "option_bandwidth": "single",
+            "planning_granularity": "minimal",
+        },
+        effective_relational_values={
+            "candor": "high",
+            "warmth": "medium",
+        },
+        intervention_family="narrow",
+        intervention_refs=("int-webui-1",),
+        prompt_contract_summary="Keep the next move narrow, direct, and execution-focused.",
+        operational_snapshot_ref="arc:webui_cleanup@snap-2026-04-07T12:10:00Z",
+    )
+    observation = OutcomeObservation(
+        observation_id="obs-webui-1",
+        attempt_id="attempt-webui-1",
+        observed_at=datetime(2026, 4, 7, 12, 18, tzinfo=UTC),
+        source_type="work_state_transition",
+        signals=("task_started", "blocker_narrowed", "clarity"),
+        signal_polarity="positive",
+        signal_strength=0.82,
+        evidence_refs=(
+            SupportTranscriptSpanRef(
+                session_id="sess-812",
+                message_start_id="msg-user-445",
+                message_end_id="msg-assistant-446",
+            ),
+        ),
+        operational_delta_refs=("task:webui-bootstrap", "blocker:script-order"),
+        notes="The user started the bootstrap task and the main blocker narrowed.",
+    )
+    case = LearningCase(
+        case_id="case-webui-1",
+        attempt_id="attempt-webui-1",
+        status="complete",
+        scope=SupportProfileScope(type="arc", id="webui_cleanup"),
+        created_at=datetime(2026, 4, 7, 12, 10, tzinfo=UTC),
+        finalized_at=datetime(2026, 4, 7, 12, 25, tzinfo=UTC),
+        aggregate_signals=("task_started", "blocker_narrowed", "clarity"),
+        positive_evidence_count=3,
+        negative_evidence_count=0,
+        contradiction_count=0,
+        conversation_score=0.78,
+        operational_score=0.91,
+        overall_score=0.85,
+        promotion_eligibility=True,
+        evidence_refs=(
+            SupportTranscriptSpanRef(
+                session_id="sess-812",
+                message_start_id="msg-user-445",
+                message_end_id="msg-assistant-446",
+            ),
+        ),
+        summary="Narrow direct execution support correlated with concrete movement in the active arc.",
+    )
+
+    attempt_record = attempt.to_record()
+    observation_record = observation.to_record()
+    case_record = case.to_record()
+
+    assert SupportAttempt.from_record(attempt_record) == attempt
+    assert OutcomeObservation.from_record(observation_record) == observation
+    assert LearningCase.from_record(case_record) == case
+    assert attempt_record["user_message_id"] == "msg-user-445"
+    assert observation_record["signals"] == '["task_started", "blocker_narrowed", "clarity"]'
+    assert case_record["scope_type"] == "arc"
+    assert case_record["promotion_eligibility"] is True
+
 
 
 def test_learning_situation_round_trips_with_embedding_contract_and_linked_interventions() -> None:

--- a/tests/test_support_learning.py
+++ b/tests/test_support_learning.py
@@ -22,6 +22,7 @@ from alfred.memory.support_learning import (
     derive_bounded_adaptation,
     derive_learning_case,
     derive_value_ledger_updates_from_cases,
+    extract_conversational_outcome_observations,
 )
 from alfred.memory.support_profile import SupportProfileScope, SupportProfileValue
 from alfred.support_policy import (
@@ -1237,3 +1238,28 @@ async def test_support_learning_core_links_intervention_situation_pattern_and_up
 
     assert behavior_contract.support_values["option_bandwidth"] == "single"
     assert behavior_contract.relational_values["candor"] == "high"
+
+
+def test_extract_conversational_outcome_observations_is_stubbed() -> None:
+    """Milestone 3B extraction is intentionally stubbed until semantic adjudication ships."""
+
+    attempt = SupportAttempt(
+        attempt_id="attempt-1",
+        session_id="session-1",
+        user_message_id="user-1",
+        assistant_message_id="assistant-1",
+        created_at=datetime(2026, 3, 30, tzinfo=UTC),
+        need="activate",
+        response_mode="execute",
+        subject_refs=("arc:webui_cleanup",),
+        active_arc_id="webui_cleanup",
+        active_domain_ids=("work",),
+        effective_support_values={"option_bandwidth": "single"},
+        effective_relational_values={"candor": "medium"},
+        intervention_family="narrow",
+        intervention_refs=(),
+        prompt_contract_summary="test",
+        operational_snapshot_ref=None,
+    )
+
+    assert extract_conversational_outcome_observations(attempt=attempt) == ()

--- a/tests/test_support_learning.py
+++ b/tests/test_support_learning.py
@@ -11,9 +11,12 @@ from alfred.memory.support_learning import (
     LearningSituation,
     OutcomeObservation,
     SupportAttempt,
+    SupportLedgerUpdateEvent,
     SupportPattern,
+    SupportPatternLedgerEntry,
     SupportProfileUpdateEvent,
     SupportTranscriptSpanRef,
+    SupportValueLedgerEntry,
     apply_bounded_adaptation,
     derive_bounded_adaptation,
 )
@@ -158,6 +161,73 @@ def test_v2_learning_artifacts_round_trip_with_real_refs() -> None:
     assert observation_record["signals"] == '["task_started", "blocker_narrowed", "clarity"]'
     assert case_record["scope_type"] == "arc"
     assert case_record["promotion_eligibility"] is True
+
+
+
+def test_v2_value_pattern_and_update_event_records_preserve_status_and_provenance() -> None:
+    """V2 ledger rows should preserve explicit statuses and provenance through record helpers."""
+
+    value_entry = SupportValueLedgerEntry(
+        value_id="val-candor-execute-1",
+        registry="relational",
+        dimension="candor",
+        scope=SupportProfileScope(type="context", id="execute"),
+        value="high",
+        status="active_auto",
+        source="auto_case",
+        confidence=0.83,
+        evidence_count=4,
+        contradiction_count=1,
+        last_case_id="case-webui-2",
+        created_at=datetime(2026, 4, 7, 12, 26, tzinfo=UTC),
+        updated_at=datetime(2026, 4, 7, 12, 31, tzinfo=UTC),
+        why="Repeated successful execute cases favored stronger candor.",
+    )
+    pattern_entry = SupportPatternLedgerEntry(
+        pattern_id="pattern-execute-directness",
+        registry="relational",
+        kind="support_preference",
+        scope=SupportProfileScope(type="context", id="execute"),
+        status="active_auto",
+        claim="Direct candor plus narrow next steps works better during execute turns.",
+        evidence_count=5,
+        contradiction_count=1,
+        confidence=0.81,
+        source_case_ids=("case-webui-1", "case-webui-2"),
+        created_at=datetime(2026, 4, 7, 12, 26, tzinfo=UTC),
+        updated_at=datetime(2026, 4, 7, 12, 31, tzinfo=UTC),
+        why="Multiple successful execute cases converged on the same support preference.",
+    )
+    update_event = SupportLedgerUpdateEvent(
+        event_id="evt-candor-auto-1",
+        entity_type="value",
+        entity_id="val-candor-execute-1",
+        registry="relational",
+        dimension_or_kind="candor",
+        scope=SupportProfileScope(type="context", id="execute"),
+        old_status="shadow",
+        new_status="active_auto",
+        old_value="medium",
+        new_value="high",
+        trigger_case_ids=("case-webui-1", "case-webui-2"),
+        reason="Repeated successful execute cases supported stronger candor.",
+        confidence=0.83,
+        created_at=datetime(2026, 4, 7, 12, 31, tzinfo=UTC),
+    )
+
+    value_record = value_entry.to_record()
+    pattern_record = pattern_entry.to_record()
+    event_record = update_event.to_record()
+
+    assert SupportValueLedgerEntry.from_record(value_record) == value_entry
+    assert SupportPatternLedgerEntry.from_record(pattern_record) == pattern_entry
+    assert SupportLedgerUpdateEvent.from_record(event_record) == update_event
+    assert value_record["status"] == "active_auto"
+    assert value_record["evidence_count"] == 4
+    assert pattern_record["source_case_ids"] == '["case-webui-1", "case-webui-2"]'
+    assert pattern_record["why"] == "Multiple successful execute cases converged on the same support preference."
+    assert event_record["old_status"] == "shadow"
+    assert event_record["trigger_case_ids"] == '["case-webui-1", "case-webui-2"]'
 
 
 

--- a/tests/test_support_learning.py
+++ b/tests/test_support_learning.py
@@ -22,7 +22,6 @@ from alfred.memory.support_learning import (
     derive_bounded_adaptation,
     derive_learning_case,
     derive_value_ledger_updates_from_cases,
-    extract_conversational_outcome_observations,
 )
 from alfred.memory.support_profile import SupportProfileScope, SupportProfileValue
 from alfred.support_policy import (
@@ -1239,27 +1238,3 @@ async def test_support_learning_core_links_intervention_situation_pattern_and_up
     assert behavior_contract.support_values["option_bandwidth"] == "single"
     assert behavior_contract.relational_values["candor"] == "high"
 
-
-def test_extract_conversational_outcome_observations_is_stubbed() -> None:
-    """Milestone 3B extraction is intentionally stubbed until semantic adjudication ships."""
-
-    attempt = SupportAttempt(
-        attempt_id="attempt-1",
-        session_id="session-1",
-        user_message_id="user-1",
-        assistant_message_id="assistant-1",
-        created_at=datetime(2026, 3, 30, tzinfo=UTC),
-        need="activate",
-        response_mode="execute",
-        subject_refs=("arc:webui_cleanup",),
-        active_arc_id="webui_cleanup",
-        active_domain_ids=("work",),
-        effective_support_values={"option_bandwidth": "single"},
-        effective_relational_values={"candor": "medium"},
-        intervention_family="narrow",
-        intervention_refs=(),
-        prompt_contract_summary="test",
-        operational_snapshot_ref=None,
-    )
-
-    assert extract_conversational_outcome_observations(attempt=attempt) == ()

--- a/tests/test_support_learning.py
+++ b/tests/test_support_learning.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 import pytest
 
 from alfred.memory.support_learning import (
+    FinalizedLearningCaseBundle,
     LearningCase,
     LearningSituation,
     OutcomeObservation,
@@ -19,6 +20,8 @@ from alfred.memory.support_learning import (
     SupportValueLedgerEntry,
     apply_bounded_adaptation,
     derive_bounded_adaptation,
+    derive_learning_case,
+    derive_value_ledger_updates_from_cases,
 )
 from alfred.memory.support_profile import SupportProfileScope, SupportProfileValue
 from alfred.support_policy import (
@@ -78,6 +81,61 @@ class FakePolicyValueStore:
                 if value.registry == registry and value.dimension == dimension and value.scope == scope:
                     return value
         return None
+
+
+def _make_finalized_learning_case_bundle(
+    *,
+    attempt_id: str,
+    case_id: str,
+    scope: SupportProfileScope,
+    created_at: datetime,
+    finalized_at: datetime | None,
+    response_mode: str,
+    support_values: dict[str, str] | None = None,
+    relational_values: dict[str, str] | None = None,
+    overall_score: float = 0.8,
+    promotion_eligibility: bool = True,
+    status: str = "complete",
+) -> FinalizedLearningCaseBundle:
+    active_arc_id = scope.id if scope.type == "arc" else None
+    attempt = SupportAttempt(
+        attempt_id=attempt_id,
+        session_id=f"session-{attempt_id}",
+        user_message_id=f"user-{attempt_id}",
+        assistant_message_id=f"assistant-{attempt_id}",
+        created_at=created_at,
+        need="activate" if scope.type == "arc" else "reflect",
+        response_mode=response_mode,
+        subject_refs=(f"{scope.type}:{scope.id}",),
+        active_arc_id=active_arc_id,
+        active_domain_ids=("work",),
+        effective_support_values=support_values or {},
+        effective_relational_values=relational_values or {},
+        intervention_family="narrow" if response_mode == "execute" else "mirror",
+        intervention_refs=(),
+        prompt_contract_summary="Test support contract summary.",
+        operational_snapshot_ref=None,
+    )
+
+    case = LearningCase(
+        case_id=case_id,
+        attempt_id=attempt.attempt_id,
+        status=status,  # type: ignore[arg-type]
+        scope=scope,
+        created_at=created_at,
+        finalized_at=finalized_at,
+        aggregate_signals=("clarity",),
+        positive_evidence_count=1 if promotion_eligibility else 0,
+        negative_evidence_count=0,
+        contradiction_count=0,
+        conversation_score=overall_score,
+        operational_score=overall_score if scope.type == "arc" else 0.0,
+        overall_score=overall_score,
+        promotion_eligibility=promotion_eligibility,
+        evidence_refs=(),
+        summary="Test learning case." if status != "open" else None,
+    )
+    return FinalizedLearningCaseBundle(learning_case=case, attempt=attempt)
 
 
 def test_v2_learning_artifacts_round_trip_with_real_refs() -> None:
@@ -161,6 +219,404 @@ def test_v2_learning_artifacts_round_trip_with_real_refs() -> None:
     assert observation_record["signals"] == '["task_started", "blocker_narrowed", "clarity"]'
     assert case_record["scope_type"] == "arc"
     assert case_record["promotion_eligibility"] is True
+
+
+
+def test_derive_learning_case_scores_conversational_and_operational_evidence() -> None:
+    """Deterministic case derivation should score mixed-source evidence into one promotable case."""
+
+    attempt = SupportAttempt(
+        attempt_id="attempt-webui-1",
+        session_id="sess-812",
+        user_message_id="msg-user-445",
+        assistant_message_id="msg-assistant-446",
+        created_at=datetime(2026, 4, 7, 12, 10, tzinfo=UTC),
+        need="activate",
+        response_mode="execute",
+        active_arc_id="webui_cleanup",
+        active_domain_ids=("work",),
+        subject_refs=("arc:webui_cleanup", "domain:work"),
+        effective_support_values={"option_bandwidth": "single"},
+        effective_relational_values={"candor": "high"},
+        intervention_family="narrow",
+        prompt_contract_summary="Keep the next move narrow and direct.",
+    )
+    observations = (
+        OutcomeObservation(
+            observation_id="obs-webui-1",
+            attempt_id=attempt.attempt_id,
+            observed_at=datetime(2026, 4, 7, 12, 15, tzinfo=UTC),
+            source_type="next_user_turn",
+            signals=("clarity", "commitment"),
+            signal_polarity="positive",
+            signal_strength=0.76,
+            evidence_refs=(
+                SupportTranscriptSpanRef(
+                    session_id=attempt.session_id,
+                    message_start_id="msg-user-447",
+                    message_end_id="msg-user-447",
+                ),
+            ),
+            notes="The user accepted the narrow plan and committed to act.",
+        ),
+        OutcomeObservation(
+            observation_id="obs-webui-2",
+            attempt_id=attempt.attempt_id,
+            observed_at=datetime(2026, 4, 7, 12, 18, tzinfo=UTC),
+            source_type="work_state_transition",
+            signals=("task_started", "blocker_resolved"),
+            signal_polarity="positive",
+            signal_strength=0.88,
+            operational_delta_refs=("task:webui-bootstrap", "blocker:script-order"),
+            notes="The user started the task and resolved the blocker.",
+        ),
+    )
+
+    learning_case = derive_learning_case(attempt=attempt, observations=observations)
+
+    assert learning_case == LearningCase(
+        case_id="case-attempt-webui-1",
+        attempt_id=attempt.attempt_id,
+        status="complete",
+        scope=SupportProfileScope(type="arc", id="webui_cleanup"),
+        created_at=attempt.created_at,
+        finalized_at=datetime(2026, 4, 7, 12, 18, tzinfo=UTC),
+        aggregate_signals=("clarity", "commitment", "task_started", "blocker_resolved"),
+        positive_evidence_count=4,
+        negative_evidence_count=0,
+        contradiction_count=0,
+        conversation_score=0.76,
+        operational_score=0.88,
+        overall_score=0.82,
+        promotion_eligibility=True,
+        evidence_refs=(
+            SupportTranscriptSpanRef(
+                session_id=attempt.session_id,
+                message_start_id="msg-user-447",
+                message_end_id="msg-user-447",
+            ),
+        ),
+        summary="Attempt attempt-webui-1 produced enough directional evidence to finalize a promotable case.",
+    )
+
+
+
+def test_derive_learning_case_marks_neutral_only_evidence_as_insufficient() -> None:
+    """Neutral-only evidence should stay inspectable but never become promotion-eligible."""
+
+    attempt = SupportAttempt(
+        attempt_id="attempt-docs-1",
+        session_id="sess-900",
+        user_message_id="msg-user-900",
+        assistant_message_id="msg-assistant-901",
+        created_at=datetime(2026, 4, 7, 13, 0, tzinfo=UTC),
+        need="reflect",
+        response_mode="review",
+        subject_refs=("domain:work",),
+        effective_support_values={"reflection_depth": "medium"},
+        effective_relational_values={"warmth": "high"},
+        intervention_family="mirror",
+        prompt_contract_summary="Mirror the uncertainty without forcing a decision.",
+    )
+    observations = (
+        OutcomeObservation(
+            observation_id="obs-docs-1",
+            attempt_id=attempt.attempt_id,
+            observed_at=datetime(2026, 4, 7, 13, 10, tzinfo=UTC),
+            source_type="manual_review",
+            signals=("follow_up_needed",),
+            signal_polarity="neutral",
+            signal_strength=0.6,
+            notes="The attempt stayed ambiguous and needs more evidence.",
+        ),
+    )
+
+    learning_case = derive_learning_case(attempt=attempt, observations=observations)
+
+    assert learning_case == LearningCase(
+        case_id="case-attempt-docs-1",
+        attempt_id=attempt.attempt_id,
+        status="insufficient_evidence",
+        scope=SupportProfileScope(type="context", id="review"),
+        created_at=attempt.created_at,
+        finalized_at=datetime(2026, 4, 7, 13, 10, tzinfo=UTC),
+        aggregate_signals=("follow_up_needed",),
+        positive_evidence_count=0,
+        negative_evidence_count=0,
+        contradiction_count=0,
+        conversation_score=0.15,
+        operational_score=0.0,
+        overall_score=0.15,
+        promotion_eligibility=False,
+        evidence_refs=(),
+        summary="Attempt attempt-docs-1 finalized with insufficient directional evidence.",
+    )
+
+
+
+def test_derive_value_ledger_updates_persists_shadow_rows_below_exact_scope_thresholds() -> None:
+    """One promotable case should persist inspectable shadow rows before exact-scope thresholds are met."""
+
+    now = datetime(2026, 4, 7, 16, 0, tzinfo=UTC)
+    arc_bundle = _make_finalized_learning_case_bundle(
+        attempt_id="attempt-arc-1",
+        case_id="case-arc-1",
+        scope=SupportProfileScope(type="arc", id="webui_cleanup"),
+        created_at=datetime(2026, 4, 7, 15, 0, tzinfo=UTC),
+        finalized_at=datetime(2026, 4, 7, 15, 10, tzinfo=UTC),
+        response_mode="execute",
+        support_values={"option_bandwidth": "single"},
+        overall_score=0.81,
+    )
+
+    arc_result = derive_value_ledger_updates_from_cases(
+        focus_bundle=arc_bundle,
+        scoped_bundles=(arc_bundle,),
+        existing_value_entries={},
+        now=now,
+    )
+
+    assert len(arc_result.value_entries) == 1
+    arc_entry = arc_result.value_entries[0]
+    assert arc_entry == SupportValueLedgerEntry(
+        value_id="value-support-option_bandwidth-arc-webui_cleanup-single",
+        registry="support",
+        dimension="option_bandwidth",
+        scope=SupportProfileScope(type="arc", id="webui_cleanup"),
+        value="single",
+        status="shadow",
+        source="auto_case",
+        confidence=0.81,
+        evidence_count=1,
+        contradiction_count=0,
+        last_case_id="case-arc-1",
+        created_at=now,
+        updated_at=now,
+        why="support option_bandwidth=single has 1 supporting promotable cases and 0 conflicting promotable cases in this arc scope.",
+    )
+    assert arc_result.update_events == (
+        SupportLedgerUpdateEvent(
+            event_id="event-value-support-option_bandwidth-arc-webui_cleanup-single-shadow-case-arc-1",
+            entity_type="value",
+            entity_id=arc_entry.value_id,
+            registry="support",
+            dimension_or_kind="option_bandwidth",
+            scope=arc_entry.scope,
+            old_status=None,
+            new_status="shadow",
+            old_value=None,
+            new_value="single",
+            trigger_case_ids=("case-arc-1",),
+            reason=arc_entry.why,
+            confidence=0.81,
+            created_at=now,
+        ),
+    )
+
+    context_bundle = _make_finalized_learning_case_bundle(
+        attempt_id="attempt-context-1",
+        case_id="case-context-1",
+        scope=SupportProfileScope(type="context", id="review"),
+        created_at=datetime(2026, 4, 7, 15, 20, tzinfo=UTC),
+        finalized_at=datetime(2026, 4, 7, 15, 30, tzinfo=UTC),
+        response_mode="review",
+        relational_values={"warmth": "high"},
+        overall_score=0.77,
+    )
+
+    context_result = derive_value_ledger_updates_from_cases(
+        focus_bundle=context_bundle,
+        scoped_bundles=(context_bundle,),
+        existing_value_entries={},
+        now=now,
+    )
+
+    assert context_result.value_entries == (
+        SupportValueLedgerEntry(
+            value_id="value-relational-warmth-context-review-high",
+            registry="relational",
+            dimension="warmth",
+            scope=SupportProfileScope(type="context", id="review"),
+            value="high",
+            status="shadow",
+            source="auto_case",
+            confidence=0.77,
+            evidence_count=1,
+            contradiction_count=0,
+            last_case_id="case-context-1",
+            created_at=now,
+            updated_at=now,
+            why="relational warmth=high has 1 supporting promotable cases and 0 conflicting promotable cases in this context scope.",
+        ),
+    )
+    assert context_result.update_events == (
+        SupportLedgerUpdateEvent(
+            event_id="event-value-relational-warmth-context-review-high-shadow-case-context-1",
+            entity_type="value",
+            entity_id="value-relational-warmth-context-review-high",
+            registry="relational",
+            dimension_or_kind="warmth",
+            scope=SupportProfileScope(type="context", id="review"),
+            old_status=None,
+            new_status="shadow",
+            old_value=None,
+            new_value="high",
+            trigger_case_ids=("case-context-1",),
+            reason="relational warmth=high has 1 supporting promotable cases and 0 conflicting promotable cases in this context scope.",
+            confidence=0.77,
+            created_at=now,
+        ),
+    )
+
+
+
+def test_derive_value_ledger_updates_promotes_after_threshold_and_blocks_when_conflicts_win() -> None:
+    """Repeated exact-scope evidence should promote, while equal-strength conflicts should block activation."""
+
+    shadow_now = datetime(2026, 4, 7, 16, 0, tzinfo=UTC)
+    first_arc_bundle = _make_finalized_learning_case_bundle(
+        attempt_id="attempt-arc-1",
+        case_id="case-arc-1",
+        scope=SupportProfileScope(type="arc", id="webui_cleanup"),
+        created_at=datetime(2026, 4, 7, 15, 0, tzinfo=UTC),
+        finalized_at=datetime(2026, 4, 7, 15, 10, tzinfo=UTC),
+        response_mode="execute",
+        support_values={"option_bandwidth": "single"},
+        overall_score=0.81,
+    )
+    first_result = derive_value_ledger_updates_from_cases(
+        focus_bundle=first_arc_bundle,
+        scoped_bundles=(first_arc_bundle,),
+        existing_value_entries={},
+        now=shadow_now,
+    )
+    existing_entries = {
+        (
+            entry.registry,
+            entry.dimension,
+            entry.scope.type,
+            entry.scope.id,
+            entry.value,
+        ): entry
+        for entry in first_result.value_entries
+    }
+
+    promote_now = datetime(2026, 4, 7, 16, 5, tzinfo=UTC)
+    second_arc_bundle = _make_finalized_learning_case_bundle(
+        attempt_id="attempt-arc-2",
+        case_id="case-arc-2",
+        scope=SupportProfileScope(type="arc", id="webui_cleanup"),
+        created_at=datetime(2026, 4, 7, 15, 30, tzinfo=UTC),
+        finalized_at=datetime(2026, 4, 7, 15, 40, tzinfo=UTC),
+        response_mode="execute",
+        support_values={"option_bandwidth": "single"},
+        overall_score=0.83,
+    )
+    promotion_result = derive_value_ledger_updates_from_cases(
+        focus_bundle=second_arc_bundle,
+        scoped_bundles=(first_arc_bundle, second_arc_bundle),
+        existing_value_entries=existing_entries,
+        now=promote_now,
+    )
+
+    assert promotion_result.value_entries == (
+        SupportValueLedgerEntry(
+            value_id="value-support-option_bandwidth-arc-webui_cleanup-single",
+            registry="support",
+            dimension="option_bandwidth",
+            scope=SupportProfileScope(type="arc", id="webui_cleanup"),
+            value="single",
+            status="active_auto",
+            source="auto_case",
+            confidence=0.82,
+            evidence_count=2,
+            contradiction_count=0,
+            last_case_id="case-arc-2",
+            created_at=shadow_now,
+            updated_at=promote_now,
+            why="support option_bandwidth=single has 2 supporting promotable cases and 0 conflicting promotable cases in this arc scope.",
+        ),
+    )
+    assert promotion_result.update_events == (
+        SupportLedgerUpdateEvent(
+            event_id="event-value-support-option_bandwidth-arc-webui_cleanup-single-active_auto-case-arc-2",
+            entity_type="value",
+            entity_id="value-support-option_bandwidth-arc-webui_cleanup-single",
+            registry="support",
+            dimension_or_kind="option_bandwidth",
+            scope=SupportProfileScope(type="arc", id="webui_cleanup"),
+            old_status="shadow",
+            new_status="active_auto",
+            old_value="single",
+            new_value="single",
+            trigger_case_ids=("case-arc-1", "case-arc-2"),
+            reason=(
+                "support option_bandwidth=single has 2 supporting promotable cases and 0 "
+                "conflicting promotable cases in this arc scope."
+            ),
+            confidence=0.82,
+            created_at=promote_now,
+        ),
+    )
+
+    conflict_now = datetime(2026, 4, 7, 16, 10, tzinfo=UTC)
+    conflict_bundles = (
+        _make_finalized_learning_case_bundle(
+            attempt_id="attempt-conflict-1",
+            case_id="case-conflict-1",
+            scope=SupportProfileScope(type="arc", id="ops_cleanup"),
+            created_at=datetime(2026, 4, 7, 14, 0, tzinfo=UTC),
+            finalized_at=datetime(2026, 4, 7, 14, 10, tzinfo=UTC),
+            response_mode="execute",
+            support_values={"option_bandwidth": "single"},
+            overall_score=0.8,
+        ),
+        _make_finalized_learning_case_bundle(
+            attempt_id="attempt-conflict-2",
+            case_id="case-conflict-2",
+            scope=SupportProfileScope(type="arc", id="ops_cleanup"),
+            created_at=datetime(2026, 4, 7, 14, 20, tzinfo=UTC),
+            finalized_at=datetime(2026, 4, 7, 14, 30, tzinfo=UTC),
+            response_mode="execute",
+            support_values={"option_bandwidth": "many"},
+            overall_score=0.79,
+        ),
+        _make_finalized_learning_case_bundle(
+            attempt_id="attempt-conflict-3",
+            case_id="case-conflict-3",
+            scope=SupportProfileScope(type="arc", id="ops_cleanup"),
+            created_at=datetime(2026, 4, 7, 14, 40, tzinfo=UTC),
+            finalized_at=datetime(2026, 4, 7, 14, 50, tzinfo=UTC),
+            response_mode="execute",
+            support_values={"option_bandwidth": "many"},
+            overall_score=0.78,
+        ),
+        _make_finalized_learning_case_bundle(
+            attempt_id="attempt-conflict-4",
+            case_id="case-conflict-4",
+            scope=SupportProfileScope(type="arc", id="ops_cleanup"),
+            created_at=datetime(2026, 4, 7, 15, 0, tzinfo=UTC),
+            finalized_at=datetime(2026, 4, 7, 15, 10, tzinfo=UTC),
+            response_mode="execute",
+            support_values={"option_bandwidth": "single"},
+            overall_score=0.82,
+        ),
+    )
+    conflict_result = derive_value_ledger_updates_from_cases(
+        focus_bundle=conflict_bundles[-1],
+        scoped_bundles=conflict_bundles,
+        existing_value_entries={},
+        now=conflict_now,
+    )
+
+    single_entry = next(entry for entry in conflict_result.value_entries if entry.value == "single")
+    many_entry = next(entry for entry in conflict_result.value_entries if entry.value == "many")
+    assert single_entry.status == "shadow"
+    assert single_entry.evidence_count == 2
+    assert single_entry.contradiction_count == 2
+    assert many_entry.status == "shadow"
+    assert many_entry.evidence_count == 2
+    assert many_entry.contradiction_count == 2
 
 
 

--- a/tests/test_support_policy.py
+++ b/tests/test_support_policy.py
@@ -727,10 +727,10 @@ def test_support_policy_runtime_builds_v2_support_attempt_from_runtime_result() 
 
 
 @pytest.mark.asyncio
-async def test_support_policy_runtime_persists_learning_situations_and_applies_bounded_support_updates(
+async def test_support_policy_runtime_does_not_persist_learning_situations_when_bounded_adaptation_disabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Runtime should persist the current learning situation and apply low-risk support updates before generation."""
+    """Runtime should not persist LearningSituation records once bounded adaptation is retired."""
 
     turn_text = "Let's continue the Web UI cleanup work thread."
     query_embedding = [0.0, 0.95, 0.1, 0.0, 0.0, 0.0, 0.95, 0.8, 0.0, 0.0, 0.0, 0.2]
@@ -811,10 +811,9 @@ async def test_support_policy_runtime_persists_learning_situations_and_applies_b
     )
 
     assert runtime_result.behavior_contract.support_values["option_bandwidth"] == "single"
-    assert len(store.saved_learning_situations) == 1
-    assert len(store.update_events) == 2
-    assert any(event.status == "applied" and event.dimension == "option_bandwidth" for event in store.update_events)
-    assert any(pattern.status == "candidate" and pattern.relational_overrides == {"candor": "high"} for pattern in store.patterns)
+    assert store.saved_learning_situations == []
+    assert store.update_events == []
+    assert store.patterns == []
 
 
 def test_support_behavior_contract_changes_across_operational_reflective_and_calibration_contexts() -> None:

--- a/tests/test_support_policy.py
+++ b/tests/test_support_policy.py
@@ -9,6 +9,7 @@ import pytest
 
 from alfred.memory.support_learning import (
     LearningSituation,
+    SupportAttempt,
     SupportPattern,
     SupportProfileUpdateEvent,
 )
@@ -648,6 +649,81 @@ async def test_support_policy_runtime_loads_active_patterns_and_support_profile_
 
     assert runtime_result.behavior_contract.support_values["option_bandwidth"] == "single"
     assert runtime_result.behavior_contract.relational_values["candor"] == "high"
+
+
+def test_support_policy_runtime_builds_v2_support_attempt_from_runtime_result() -> None:
+    """Runtime should derive one typed v2 support attempt from the reply contract and real refs."""
+
+    runtime = SupportPolicyRuntime(
+        store=FakeSupportProfileStore(),
+        embedder=FakeEmbedder({}),  # type: ignore[arg-type]
+    )
+    assessment = SupportTurnAssessment(
+        need="activate",
+        subjects=(
+            ResolvedSubject(kind="arc", id="webui_cleanup"),
+            ResolvedSubject(kind="domain", id="work"),
+        ),
+    )
+    resolved_policy = ResolvedSupportPolicy(
+        assessment=assessment,
+        response_mode="execute",
+        relational_values={
+            "warmth": "medium",
+            "companionship": "medium",
+            "candor": "high",
+            "challenge": "medium",
+            "authority": "medium",
+            "emotional_attunement": "medium",
+            "analytical_depth": "medium",
+            "momentum_pressure": "high",
+        },
+        support_values={
+            "planning_granularity": "minimal",
+            "option_bandwidth": "single",
+            "proactivity_level": "high",
+            "accountability_style": "firm",
+            "recovery_style": "steady",
+            "reflection_depth": "light",
+            "pacing": "brisk",
+            "recommendation_forcefulness": "high",
+        },
+        primary_arc_id="webui_cleanup",
+        domain_ids=("work",),
+    )
+    behavior_contract = compile_support_behavior_contract(resolved_policy)
+
+    attempt = runtime.build_support_attempt(
+        runtime_result=type("RuntimeResult", (), {
+            "assessment": assessment,
+            "response_mode": "execute",
+            "resolved_policy": resolved_policy,
+            "behavior_contract": behavior_contract,
+        })(),
+        session_id="session-123",
+        user_message_id="msg-user-123",
+        assistant_message_id="msg-assistant-123",
+        created_at=_ts(9, 45),
+    )
+
+    assert attempt == SupportAttempt(
+        attempt_id="attempt-msg-assistant-123",
+        session_id="session-123",
+        user_message_id="msg-user-123",
+        assistant_message_id="msg-assistant-123",
+        created_at=_ts(9, 45),
+        need="activate",
+        response_mode="execute",
+        subject_refs=("arc:webui_cleanup", "domain:work"),
+        active_arc_id="webui_cleanup",
+        active_domain_ids=("work",),
+        effective_support_values=behavior_contract.support_values,
+        effective_relational_values=behavior_contract.relational_values,
+        intervention_family="narrow",
+        intervention_refs=(),
+        prompt_contract_summary="need=activate; mode=execute; family=narrow; subjects=[arc:webui_cleanup, domain:work]",
+        operational_snapshot_ref=None,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_support_reflection.py
+++ b/tests/test_support_reflection.py
@@ -7,7 +7,13 @@ from datetime import UTC, datetime
 
 import pytest
 
-from alfred.memory.support_learning import LearningSituation, SupportPattern, SupportProfileUpdateEvent
+from alfred.memory.support_learning import (
+    LearningSituation,
+    SupportLedgerUpdateEvent,
+    SupportPattern,
+    SupportProfileUpdateEvent,
+    SupportValueLedgerEntry,
+)
 from alfred.memory.support_memory import LifeDomain, OperationalArc
 from alfred.memory.support_profile import SupportProfileScope, SupportProfileValue
 from alfred.support_policy import ResolvedSubject, SupportTurnAssessment
@@ -30,6 +36,8 @@ class FakeReflectionStore:
     runtime_patterns: list[SupportPattern] = field(default_factory=list)
     inspection_patterns: list[SupportPattern] = field(default_factory=list)
     update_events: list[SupportProfileUpdateEvent] = field(default_factory=list)
+    value_ledger_entries: list[SupportValueLedgerEntry] = field(default_factory=list)
+    ledger_update_events: list[SupportLedgerUpdateEvent] = field(default_factory=list)
     learning_situations: list[LearningSituation] = field(default_factory=list)
     similar_situations: list[tuple[LearningSituation, float]] = field(default_factory=list)
     arcs: list[OperationalArc] = field(default_factory=list)
@@ -102,6 +110,12 @@ class FakeReflectionStore:
             if event.event_id == event_id:
                 return event
         return None
+
+    async def list_support_value_ledger_entries(self) -> list[SupportValueLedgerEntry]:
+        return list(self.value_ledger_entries)
+
+    async def list_support_ledger_update_events(self) -> list[SupportLedgerUpdateEvent]:
+        return list(self.ledger_update_events)
 
     async def list_recent_learning_situations(self, *, limit: int = 6) -> list[LearningSituation]:
         return list(self.learning_situations)[:limit]
@@ -224,6 +238,67 @@ def _make_learning_situation(*, situation_id: str, arc_id: str | None = None) ->
         relational_values_applied={"candor": "high"},
         user_response_signals=("clarity",),
         outcome_signals=("next_step_chosen",),
+    )
+
+
+def _make_value_ledger_entry(
+    *,
+    value_id: str,
+    registry: str,
+    dimension: str,
+    scope: SupportProfileScope,
+    value: str,
+    status: str,
+    confidence: float,
+    evidence_count: int,
+    contradiction_count: int,
+    updated_at: datetime,
+) -> SupportValueLedgerEntry:
+    return SupportValueLedgerEntry(
+        value_id=value_id,
+        registry=registry,  # type: ignore[arg-type]
+        dimension=dimension,
+        scope=scope,
+        value=value,
+        status=status,  # type: ignore[arg-type]
+        source="case_promotion",
+        confidence=confidence,
+        evidence_count=evidence_count,
+        contradiction_count=contradiction_count,
+        last_case_id="case-1",
+        created_at=_ts(7, 30),
+        updated_at=updated_at,
+        why="Derived from finalized learning cases.",
+    )
+
+
+
+def _make_ledger_update_event(
+    *,
+    event_id: str,
+    entity_id: str,
+    registry: str,
+    dimension: str,
+    scope: SupportProfileScope,
+    new_status: str,
+    new_value: str,
+    created_at: datetime,
+) -> SupportLedgerUpdateEvent:
+    return SupportLedgerUpdateEvent(
+        event_id=event_id,
+        entity_type="value",
+        entity_id=entity_id,
+        registry=registry,  # type: ignore[arg-type]
+        dimension_or_kind=dimension,
+        scope=scope,
+        old_status=None,
+        new_status=new_status,  # type: ignore[arg-type]
+        old_value=None,
+        new_value=new_value,
+        trigger_case_ids=("case-1", "case-2"),
+        reason="Evidence threshold met.",
+        confidence=0.82,
+        created_at=created_at,
     )
 
 
@@ -400,6 +475,97 @@ def test_review_card_rejects_unknown_card_kinds_and_missing_next_actions() -> No
             evidence_refs=("sit-1",),
             proposed_action="",
         )
+
+
+@pytest.mark.asyncio
+async def test_support_inspection_snapshot_includes_v2_value_ledger_entries_and_recent_ledger_events() -> None:
+    store = _make_runtime_store()
+    execute_scope = SupportProfileScope(type="context", id="execute")
+    arc_scope = SupportProfileScope(type="arc", id="webui_cleanup")
+
+    store.value_ledger_entries = [
+        _make_value_ledger_entry(
+            value_id="val-1",
+            registry="relational",
+            dimension="candor",
+            scope=execute_scope,
+            value="medium",
+            status="shadow",
+            confidence=0.62,
+            evidence_count=1,
+            contradiction_count=0,
+            updated_at=_ts(11, 0),
+        ),
+        _make_value_ledger_entry(
+            value_id="val-2",
+            registry="support",
+            dimension="option_bandwidth",
+            scope=execute_scope,
+            value="single",
+            status="active_auto",
+            confidence=0.81,
+            evidence_count=3,
+            contradiction_count=0,
+            updated_at=_ts(11, 5),
+        ),
+        _make_value_ledger_entry(
+            value_id="val-3",
+            registry="support",
+            dimension="planning_granularity",
+            scope=arc_scope,
+            value="minimal",
+            status="confirmed",
+            confidence=0.93,
+            evidence_count=4,
+            contradiction_count=0,
+            updated_at=_ts(11, 10),
+        ),
+    ]
+
+    store.ledger_update_events = [
+        _make_ledger_update_event(
+            event_id="led-1",
+            entity_id="val-1",
+            registry="relational",
+            dimension="candor",
+            scope=execute_scope,
+            new_status="shadow",
+            new_value="medium",
+            created_at=_ts(10, 0),
+        ),
+        _make_ledger_update_event(
+            event_id="led-2",
+            entity_id="val-2",
+            registry="support",
+            dimension="option_bandwidth",
+            scope=execute_scope,
+            new_status="active_auto",
+            new_value="single",
+            created_at=_ts(10, 30),
+        ),
+    ]
+
+    runtime = SupportReflectionRuntime(store=store)  # type: ignore[arg-type]
+
+    snapshot = await runtime.build_inspection_snapshot(response_mode="execute", arc_id="webui_cleanup")
+
+    value_entries = snapshot.learned_state.value_ledger_entries
+    assert [entry.registry for entry in value_entries] == ["relational", "support", "support"]
+    assert value_entries[0].dimension == "candor"
+    assert value_entries[0].status == "shadow"
+    assert value_entries[1].dimension == "option_bandwidth"
+    assert value_entries[1].value == "single"
+
+    summary = snapshot.learned_state.value_ledger_summary
+    assert summary["total"] == 3
+    assert summary["counts_by_registry"] == {"relational": 1, "support": 2}
+    assert summary["counts_by_status"]["shadow"] == 1
+    assert summary["counts_by_status"]["active_auto"] == 1
+    assert summary["counts_by_status"]["confirmed"] == 1
+
+    recent_events = snapshot.learned_state.recent_ledger_update_events
+    assert [event.event_id for event in recent_events] == ["led-2", "led-1"]
+    assert recent_events[0].new_status == "active_auto"
 
 
 @pytest.mark.asyncio

--- a/tests/test_template_sync_docs.py
+++ b/tests/test_template_sync_docs.py
@@ -17,6 +17,8 @@ def test_template_sync_guide_documents_sync_store_conflicts_and_recovery() -> No
     assert ">>>>>>> theirs" in guide
     assert "/context" in guide
     assert "WebUI" in guide
+    assert "prompt fragment" in guide.lower()
+    assert "persistent warning banner" in guide.lower()
     assert "fail closed" in guide.lower()
     assert "manual recovery" in guide.lower()
 
@@ -39,4 +41,6 @@ def test_architecture_doc_mentions_workspace_scoped_sync_records_and_blocked_fil
     assert "template-sync.md" in architecture
     assert "/context" in architecture
     assert "WebUI" in architecture
+    assert "prompt fragments" in architecture.lower()
+    assert "warning banner" in architecture.lower()
     assert "blocked" in architecture.lower()

--- a/tests/webui/test_context_menu_browser.py
+++ b/tests/webui/test_context_menu_browser.py
@@ -81,7 +81,10 @@ async def test_browser_context_menu_sheet_uses_theme_tokens() -> None:
                     </div>
                     <div class="message-bubble">
                       <span class="message-avatar-small">👤</span>
-                      <span class="message-content">This context menu sheet should feel like a themed surface and keep enough width to avoid cramped labels.</span>
+                      <span class="message-content">
+                        This context menu sheet should feel like a themed surface and keep enough width
+                        to avoid cramped labels.
+                      </span>
                     </div>
                   `;
                   messageList.appendChild(message);
@@ -104,6 +107,9 @@ async def test_browser_context_menu_sheet_uses_theme_tokens() -> None:
             menu = page.locator('.context-menu[data-layout="sheet"]')
             await menu.wait_for(state="visible", timeout=10000)
 
+            close_button = menu.locator('.context-menu-close')
+            await close_button.wait_for(state="visible", timeout=10000)
+
             menu_text = await menu.text_content()
             assert menu_text is not None
             assert "Copy Text" in menu_text
@@ -117,12 +123,18 @@ async def test_browser_context_menu_sheet_uses_theme_tokens() -> None:
                 """
                 () => {
                   const probe = document.createElement('div');
-                  probe.style.cssText = 'position: fixed; left: -9999px; top: -9999px; background: var(--surface-panel-bg); border: 1px solid var(--surface-panel-border); color: var(--surface-panel-header-text);';
+                  probe.style.cssText =
+                    'position: fixed; left: -9999px; top: -9999px;' +
+                    ' background: var(--surface-panel-bg);' +
+                    ' border: 1px solid var(--surface-panel-border);' +
+                    ' color: var(--surface-panel-header-text);';
                   document.body.appendChild(probe);
 
                   const menu = document.querySelector('.context-menu');
+                  const closeButton = document.querySelector('.context-menu .context-menu-close');
                   const probeStyle = getComputedStyle(probe);
                   const menuStyle = menu ? getComputedStyle(menu) : null;
+                  const closeStyle = closeButton ? getComputedStyle(closeButton) : null;
 
                   return {
                     probeBg: probeStyle.backgroundColor,
@@ -132,6 +144,8 @@ async def test_browser_context_menu_sheet_uses_theme_tokens() -> None:
                     menuBorder: menuStyle ? menuStyle.borderTopColor : '',
                     menuText: menuStyle ? menuStyle.color : '',
                     menuLayout: menu?.dataset.layout || '',
+                    closeText: closeStyle ? closeStyle.color : '',
+                    closeBorder: closeStyle ? closeStyle.borderTopColor : '',
                   };
                 }
                 """,
@@ -141,12 +155,17 @@ async def test_browser_context_menu_sheet_uses_theme_tokens() -> None:
             assert menu_style["menuBg"] == menu_style["probeBg"]
             assert menu_style["menuBorder"] == menu_style["probeBorder"]
             assert menu_style["menuText"] == menu_style["probeText"]
+            assert menu_style["closeText"] == menu_style["probeText"]
+            assert menu_style["closeBorder"] == menu_style["probeBorder"]
 
             box = await menu.bounding_box()
             assert box is not None
             assert box["width"] > 340
             assert box["x"] <= 12
             assert box["y"] > 500
+
+            await close_button.click()
+            await menu.wait_for(state="detached", timeout=10000)
 
             await browser.close()
     finally:

--- a/tests/webui/test_context_warning_browser.py
+++ b/tests/webui/test_context_warning_browser.py
@@ -12,6 +12,7 @@ import pytest
 import uvicorn
 from playwright.async_api import async_playwright
 
+from alfred.context_display import ContextConflictStatus, ContextStatus
 from alfred.interfaces.webui.server import create_app
 from tests.webui.fakes import FakeAlfred
 
@@ -185,6 +186,64 @@ async def test_browser_context_viewer_renders_truthful_section_counts() -> None:
 
                 assert (await second_system_badge.text_content() or "").strip() == "1 active / 1 disabled"
                 assert (await second_session_badge.text_content() or "").strip() == "2 displayed / 5 included / 8 total messages"
+                await browser.close()
+    finally:
+        server.should_exit = True
+        thread.join(timeout=5)
+
+
+@pytest.mark.asyncio
+@pytest.mark.slow
+async def test_browser_shows_persistent_context_conflict_banner_without_context_command() -> None:
+    port = _find_free_port()
+    fake_alfred = FakeAlfred()
+    context_status = ContextStatus(
+        blocked_context_files=["SOUL.md"],
+        conflicted_context_files=[
+            ContextConflictStatus(
+                id="soul",
+                name="soul",
+                label="SOUL.md",
+                reason="Conflicted managed prompt fragment prompts/voice.md blocks SOUL.md",
+            )
+        ],
+        disabled_sections=["TOOLS"],
+        warnings=["Disabled sections: TOOLS"],
+    )
+
+    config = uvicorn.Config(
+        create_app(alfred_instance=fake_alfred, debug=True),
+        host="127.0.0.1",
+        port=port,
+        log_level="warning",
+    )
+    server = uvicorn.Server(config)
+    thread = Thread(target=server.run, daemon=True)
+    thread.start()
+
+    try:
+        await _wait_for_server(port)
+
+        with patch("alfred.context_display.get_context_status", AsyncMock(return_value=context_status)):
+            async with async_playwright() as playwright:
+                browser = await playwright.chromium.launch()
+                page = await browser.new_page(viewport={"width": 1440, "height": 900})
+                await page.goto(f"http://127.0.0.1:{port}/static/index.html", wait_until="domcontentloaded")
+
+                await page.wait_for_function(
+                    "() => document.querySelector('#connection-pill')?.classList.contains('connected')",
+                    timeout=10000,
+                )
+
+                banner = page.locator('#context-warning-banner')
+                await banner.wait_for(state='visible', timeout=10000)
+
+                banner_text = await banner.text_content()
+                assert banner_text is not None
+                assert "Context warnings" in banner_text
+                assert "SOUL.md" in banner_text
+                assert "prompts/voice.md" in banner_text
+                assert "Disabled sections: TOOLS" in banner_text
                 await browser.close()
     finally:
         server.should_exit = True

--- a/tests/webui/test_protocol.py
+++ b/tests/webui/test_protocol.py
@@ -220,6 +220,38 @@ def test_status_update_message_structure():
     }
 
 
+def test_status_update_message_allows_context_status_snapshot():
+    """status.update may include persistent context-health warnings for the Web UI."""
+    message: StatusUpdateMessage = {
+        "type": "status.update",
+        "payload": {
+            "model": "kimi-k2-5",
+            "contextTokens": 2450,
+            "contextWindowTokens": 272000,
+            "inputTokens": 1200,
+            "outputTokens": 850,
+            "cacheReadTokens": 2000,
+            "reasoningTokens": 150,
+            "queueLength": 2,
+            "isStreaming": True,
+            "contextStatus": {
+                "blockedContextFiles": ["SOUL.md"],
+                "conflictedContextFiles": [
+                    {
+                        "id": "soul",
+                        "name": "soul",
+                        "label": "SOUL.md",
+                        "reason": "Conflicted managed prompt fragment prompts/voice.md blocks SOUL.md",
+                    }
+                ],
+                "warnings": ["Disabled sections: TOOLS"],
+            },
+        },
+    }
+    assert message["payload"]["contextStatus"]["blockedContextFiles"] == ["SOUL.md"]
+    assert message["payload"]["contextStatus"]["conflictedContextFiles"][0]["label"] == "SOUL.md"
+
+
 def test_toast_message_structure():
     """Verify toast message has correct structure."""
     message: ToastMessage = {

--- a/tests/webui/test_server_parity.py
+++ b/tests/webui/test_server_parity.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
+from alfred.context_display import ContextConflictStatus, ContextStatus
 from alfred.interfaces.webui import create_app
 from alfred.interfaces.webui.daemon_bootstrap import DaemonBootstrapResult
 from alfred.token_tracker import TokenTracker
@@ -220,6 +221,46 @@ def test_status_update_includes_context_window_tokens_for_known_model() -> None:
     assert status_update["type"] == "status.update"
     assert status_update["payload"]["contextTokens"] == 68272
     assert status_update["payload"]["contextWindowTokens"] == 272000
+
+
+def test_status_update_includes_context_status_snapshot() -> None:
+    """Status updates should include persistent context-health warnings for the Web UI banner."""
+
+    fake_alfred = FakeAlfred()
+    client = TestClient(create_app(alfred_instance=fake_alfred))
+    context_status = ContextStatus(
+        blocked_context_files=["SOUL.md"],
+        conflicted_context_files=[
+            ContextConflictStatus(
+                id="soul",
+                name="soul",
+                label="SOUL.md",
+                reason="Conflicted managed prompt fragment prompts/voice.md blocks SOUL.md",
+            )
+        ],
+        disabled_sections=["TOOLS"],
+        warnings=["Disabled sections: TOOLS"],
+    )
+
+    with (
+        patch("alfred.context_display.get_context_status", AsyncMock(return_value=context_status)),
+        client.websocket_connect("/ws") as websocket,
+    ):
+        _, _, status_update = _connect_and_consume_startup(websocket)
+
+    assert status_update["type"] == "status.update"
+    assert status_update["payload"]["contextStatus"] == {
+        "blockedContextFiles": ["SOUL.md"],
+        "conflictedContextFiles": [
+            {
+                "id": "soul",
+                "name": "soul",
+                "label": "SOUL.md",
+                "reason": "Conflicted managed prompt fragment prompts/voice.md blocks SOUL.md",
+            }
+        ],
+        "warnings": ["Disabled sections: TOOLS"],
+    }
 
 
 def test_new_command_resets_status_totals_for_fresh_session() -> None:

--- a/tests/webui/test_support_value_ledger_browser.py
+++ b/tests/webui/test_support_value_ledger_browser.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import asyncio
+import socket
+import time
+import urllib.request
+from threading import Thread
+from typing import cast
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import uvicorn
+from playwright.async_api import async_playwright
+
+from alfred.interfaces.webui.server import create_app
+from tests.webui.fakes import FakeAlfred
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return cast(int, sock.getsockname()[1])
+
+
+async def _wait_for_server(port: int, timeout: float = 20.0) -> None:
+    deadline = time.time() + timeout
+    url = f"http://127.0.0.1:{port}/health"
+    last_error: Exception | None = None
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=1) as response:
+                if response.status == 200:
+                    return
+        except Exception as exc:  # noqa: BLE001
+            last_error = exc
+        await asyncio.sleep(0.25)
+    raise RuntimeError(f"server did not start: {last_error}")
+
+
+@pytest.mark.asyncio
+@pytest.mark.slow
+async def test_browser_context_viewer_renders_support_value_ledger_entries() -> None:
+    port = _find_free_port()
+    fake_alfred = FakeAlfred()
+
+    context_data = {
+        "system_prompt": {"sections": [], "total_tokens": 0},
+        "blocked_context_files": [],
+        "conflicted_context_files": [],
+        "disabled_sections": [],
+        "warnings": [],
+        "support_state": {
+            "enabled": True,
+            "request": {"response_mode": "execute", "arc_id": "webui_cleanup"},
+            "summary": {
+                "response_mode": "execute",
+                "active_arc_id": "webui_cleanup",
+                "active_pattern_count": 0,
+                "candidate_pattern_count": 0,
+                "confirmed_pattern_count": 0,
+                "recent_update_event_count": 0,
+                "recent_intervention_count": 0,
+                "active_domain_count": 0,
+                "active_arc_count": 0,
+            },
+            "active_runtime_state": {
+                "response_mode": "execute",
+                "active_arc_id": "webui_cleanup",
+                "effective_support_values": {},
+                "effective_relational_values": {},
+                "active_patterns": [],
+            },
+            "learned_state": {
+                "candidate_patterns_count": 0,
+                "confirmed_patterns_count": 0,
+                "recent_update_event_count": 0,
+                "recent_intervention_count": 0,
+                "candidate_patterns": [],
+                "confirmed_patterns": [],
+                "recent_update_events": [],
+                "value_ledger_entries": [
+                    {
+                        "value_id": "val-1",
+                        "registry": "support",
+                        "dimension": "option_bandwidth",
+                        "scope": {"type": "context", "id": "execute", "label": "context:execute"},
+                        "value": "single",
+                        "status": "active_auto",
+                        "confidence": 0.81,
+                        "evidence_count": 3,
+                        "contradiction_count": 0,
+                        "last_case_id": "case-1",
+                        "updated_at": "2026-03-23T00:00:00+00:00",
+                        "why": "Evidence threshold met.",
+                    }
+                ],
+                "value_ledger_summary": {
+                    "total": 1,
+                    "counts_by_status": {"active_auto": 1},
+                    "counts_by_registry": {"support": 1},
+                },
+                "recent_ledger_update_events": [
+                    {
+                        "event_id": "led-1",
+                        "entity_type": "value",
+                        "entity_id": "val-1",
+                        "registry": "support",
+                        "dimension_or_kind": "option_bandwidth",
+                        "scope": {"type": "context", "id": "execute", "label": "context:execute"},
+                        "old_status": None,
+                        "new_status": "active_auto",
+                        "old_value": None,
+                        "new_value": "single",
+                        "trigger_case_ids": ["case-1"],
+                        "reason": "Evidence threshold met.",
+                        "confidence": 0.82,
+                        "created_at": "2026-03-23T00:00:00+00:00",
+                    }
+                ],
+                "recent_interventions": [],
+            },
+            "active_domains": [],
+            "active_arcs": [],
+        },
+        "memories": {"displayed": 0, "total": 0, "items": [], "tokens": 0},
+        "session_history": {"displayed": 0, "included": 0, "total": 0, "messages": [], "tokens": 0},
+        "tool_calls": {"displayed": 0, "total": 0, "items": [], "tokens": 0},
+        "self_model": {
+            "identity": {"name": "Alfred", "role": "Assistant"},
+            "runtime": {"interface": "webui", "session_id": "browser-session", "daemon_mode": False},
+            "capabilities": {"memory_enabled": True, "search_enabled": True, "tools_count": 0, "tools": []},
+            "context_pressure": {"message_count": 0, "memory_count": 0, "approximate_tokens": 1},
+        },
+        "total_tokens": 1,
+    }
+
+    config = uvicorn.Config(
+        create_app(alfred_instance=fake_alfred, debug=True),
+        host="127.0.0.1",
+        port=port,
+        log_level="warning",
+    )
+    server = uvicorn.Server(config)
+    thread = Thread(target=server.run, daemon=True)
+    thread.start()
+
+    try:
+        await _wait_for_server(port)
+
+        with patch("alfred.context_display.get_context_display", AsyncMock(return_value=context_data)):
+            async with async_playwright() as playwright:
+                browser = await playwright.chromium.launch()
+                page = await browser.new_page(viewport={"width": 1440, "height": 900})
+                await page.goto(
+                    f"http://127.0.0.1:{port}/static/index.html",
+                    wait_until="domcontentloaded",
+                )
+
+                await page.wait_for_function(
+                    "() => document.querySelector('#connection-pill')?.classList.contains('connected')",
+                    timeout=10000,
+                )
+
+                await page.fill("#message-input", "/context")
+                await page.click("#send-button")
+
+                await page.wait_for_function(
+                    "() => document.querySelectorAll('context-viewer').length === 1",
+                    timeout=10000,
+                )
+
+                ledger_title = page.locator("context-viewer .card-title", has_text="Value Ledger")
+                assert await ledger_title.count() >= 1
+
+                entry = page.locator("context-viewer .support-ledger-entry").first
+                entry_text = await entry.inner_text()
+                assert "support:option_bandwidth" in entry_text
+                assert "active_auto" in entry_text
+                assert "single" in entry_text
+
+                update_title = page.locator("context-viewer .card-title", has_text="Ledger Updates")
+                assert await update_title.count() >= 1
+
+                update_row = page.locator("context-viewer .support-ledger-event").first
+                update_text = await update_row.inner_text()
+                assert "value support:option_bandwidth" in update_text
+                assert "active_auto" in update_text
+
+                await browser.close()
+    finally:
+        server.should_exit = True
+        thread.join(timeout=5)

--- a/tests/webui/test_validation.py
+++ b/tests/webui/test_validation.py
@@ -259,8 +259,42 @@ def test_status_update_message():
             "reasoningTokens": 10,
             "queueLength": 0,
             "isStreaming": True,
+            "contextStatus": None,
         },
     }
+
+
+def test_status_update_message_accepts_context_status_snapshot():
+    """Verify StatusUpdateMessage accepts persistent context-health warnings."""
+    message = StatusUpdateMessage(
+        type="status.update",
+        payload=StatusUpdatePayload(
+            model="claude-3-sonnet",
+            context_tokens=1000,
+            input_tokens=50,
+            output_tokens=25,
+            cache_read_tokens=100,
+            reasoning_tokens=10,
+            queue_length=0,
+            is_streaming=True,
+            context_status={
+                "blockedContextFiles": ["SOUL.md"],
+                "conflictedContextFiles": [
+                    {
+                        "id": "soul",
+                        "name": "soul",
+                        "label": "SOUL.md",
+                        "reason": "Conflicted managed prompt fragment prompts/voice.md blocks SOUL.md",
+                    }
+                ],
+                "warnings": ["Disabled sections: TOOLS"],
+            },
+        ),
+    )
+
+    assert message.payload.context_status is not None
+    assert message.payload.context_status.blocked_context_files == ["SOUL.md"]
+    assert message.payload.context_status.conflicted_context_files[0].label == "SOUL.md"
 
 
 def test_status_update_message_rejects_daemon_fields():


### PR DESCRIPTION
## Summary
- ship the PRD #183 support learning v2 foundation around SupportAttempt -> OutcomeObservation -> LearningCase
- use the v2 value ledger as the runtime source for exact-scope support and relational auto-activation
- expose the learned-state ledger consistently through /context and mark PRD #183 complete for the shipped foundation slice

## Validation
- pre-commit checks on commit (ruff, mypy, completions sync)
- uv run ruff check src/alfred/alfred.py src/alfred/context_display.py src/alfred/memory/support_learning.py src/alfred/storage/sqlite.py
- uv run mypy --strict src/alfred/alfred.py src/alfred/context_display.py src/alfred/memory/support_learning.py src/alfred/storage/sqlite.py
